### PR TITLE
Add Support For clouds.yaml

### DIFF
--- a/actions/src/lib/base.py
+++ b/actions/src/lib/base.py
@@ -29,9 +29,13 @@ class OpenStackBaseAction(Action):
         # Copy over current environment so that the pythonpath for openstack command is
         # still available.
         env = os.environ.copy()
-        # If available source the openstackrc file before running the command.
-        # The precedence order is openstackrc > token > password
-        if self.openstackrc:
+        # If "cloud" was specified, use a clouds.yaml file for authentication.
+        # Next, check for an openstackrc file specified in the pack configuration.
+        # Finally, check for pack configured token or password.
+        # The precedence order is cloud > openstackrc > token > password.
+        if 'cloud' in kwargs:
+            cmd.append('--os-cloud %s' % kwargs['cloud'])
+        elif self.openstackrc:
             cmd[:0] = ['.', self.openstackrc, '&&']
         else:
             env.update(self.token or self.password)

--- a/etc/autogen.py
+++ b/etc/autogen.py
@@ -186,7 +186,8 @@ class MetaDataWriter(object):
     def write(self, command):
         metadata_file_path = os.path.join(self._base_path, '%s.%s' % (command['name'], 'yaml'))
         with open(metadata_file_path, 'w') as out:
-            out.write(yaml.safe_dump(command, explicit_start=True, default_flow_style=False, indent=4))
+            out.write(yaml.safe_dump(command, explicit_start=True,
+                                     default_flow_style=False, indent=4))
         return metadata_file_path
 
 

--- a/pack.yaml
+++ b/pack.yaml
@@ -1,6 +1,8 @@
 ---
 name: openstack
 description: OpenStack integration pack
-version: 0.1.0
+version: 0.2.0
 author: StackStorm Engineering Team
 email: support@stackstorm.com
+contributors:
+  - Joe Topjian <joe@topjian.net>


### PR DESCRIPTION
This commit adds support to specify a cloud defined in a clouds.yaml
file. This enables the OpenStack pack to be used across multiple
clouds / regions as well as to specify a different cloud /region
per action.

Additional changes were made to etc/autogen.py to continue processing
when an action could not be created, handles parameters with dashes in
their name, unicode yaml tags, and a standard clouds parameter.