### PR TITLE
Specify Project per Action

### DIFF
--- a/actions/address.scope.delete.yaml
+++ b/actions/address.scope.delete.yaml
@@ -1,0 +1,28 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: address.scope.delete
+parameters:
+    address_scope:
+        description: Address scope(s) to delete (name or ID)
+        required: true
+        type: string
+    base:
+        default: address scope delete
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('address_scope_delete = openstackclient.network.v2.address_scope:DeleteAddressScope')
+        immutable: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+runner_type: run-python

--- a/actions/address.scope.set.yaml
+++ b/actions/address.scope.set.yaml
@@ -1,0 +1,39 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: address.scope.set
+parameters:
+    address_scope:
+        description: Address scope to modify (name or ID)
+        required: true
+        type: string
+    base:
+        default: address scope set
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('address_scope_set = openstackclient.network.v2.address_scope:SetAddressScope')
+        immutable: true
+        type: string
+    name:
+        description: Set address scope name
+        type: string
+    no_share:
+        default: false
+        description: Do not share the address scope between projects
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    share:
+        default: false
+        description: Share the address scope between projects
+        type: boolean
+runner_type: run-python

--- a/actions/address.scope.show.yaml
+++ b/actions/address.scope.show.yaml
@@ -1,0 +1,37 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: address.scope.show
+parameters:
+    address_scope:
+        description: Address scope to display (name or ID)
+        required: true
+        type: string
+    base:
+        default: address scope show
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('address_scope_show = openstackclient.network.v2.address_scope:ShowAddressScope')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: json, shell,
+            table, value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+runner_type: run-python

--- a/actions/aggregate.add.host.yaml
+++ b/actions/aggregate.add.host.yaml
@@ -1,5 +1,5 @@
 ---
-description: Add host to aggregate
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: aggregate.add.host
@@ -12,17 +12,30 @@ parameters:
         default: aggregate add host
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('aggregate_add_host = openstackclient.compute.v2.aggregate:AddAggregateHost')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
         type: string
     host:
         description: Host to add to <aggregate>
         required: true
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
 runner_type: run-python

--- a/actions/aggregate.create.yaml
+++ b/actions/aggregate.create.yaml
@@ -1,5 +1,5 @@
 ---
-description: Create a new aggregate
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: aggregate.create
@@ -8,18 +8,31 @@ parameters:
         default: aggregate create
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('aggregate_create = openstackclient.compute.v2.aggregate:CreateAggregate')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
         type: string
     name:
         description: New aggregate name
         required: true
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     property:
         description: Property to add to this aggregate (repeat option to set multiple

--- a/actions/aggregate.delete.yaml
+++ b/actions/aggregate.delete.yaml
@@ -1,19 +1,28 @@
 ---
-description: Delete an existing aggregate
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: aggregate.delete
 parameters:
     aggregate:
-        description: Aggregate to delete (name or ID)
+        description: Aggregate(s) to delete (name or ID)
         required: true
         type: string
     base:
         default: aggregate delete
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('aggregate_delete = openstackclient.compute.v2.aggregate:DeleteAggregate')
         immutable: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
 runner_type: run-python

--- a/actions/aggregate.list.yaml
+++ b/actions/aggregate.list.yaml
@@ -1,5 +1,5 @@
 ---
-description: List all aggregates
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: aggregate.list
@@ -8,17 +8,30 @@ parameters:
         default: aggregate list
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('aggregate_list = openstackclient.compute.v2.aggregate:ListAggregate')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: csv, html, json,
-            table, yaml)'
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
         type: string
     long:
         default: false
         description: List additional fields in output
         type: boolean
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
 runner_type: run-python

--- a/actions/aggregate.remove.host.yaml
+++ b/actions/aggregate.remove.host.yaml
@@ -1,5 +1,5 @@
 ---
-description: Remove host from aggregate
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: aggregate.remove.host
@@ -12,17 +12,30 @@ parameters:
         default: aggregate remove host
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('aggregate_remove_host = openstackclient.compute.v2.aggregate:RemoveAggregateHost')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
         type: string
     host:
         description: Host to remove from <aggregate>
         required: true
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
 runner_type: run-python

--- a/actions/aggregate.set.yaml
+++ b/actions/aggregate.set.yaml
@@ -1,5 +1,5 @@
 ---
-description: Set aggregate properties
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: aggregate.set
@@ -12,17 +12,26 @@ parameters:
         default: aggregate set
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('aggregate_set = openstackclient.compute.v2.aggregate:SetAggregate')
         immutable: true
         type: string
-    format:
-        default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
-            table, value, yaml)'
-        type: string
     name:
         description: Set aggregate name
+        type: string
+    no_property:
+        default: false
+        description: Remove all properties from <aggregate> (specify both --property
+            and --no-property to overwrite the current properties)
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     property:
         description: Property to set on <aggregate> (repeat option to set multiple

--- a/actions/aggregate.show.yaml
+++ b/actions/aggregate.show.yaml
@@ -1,5 +1,5 @@
 ---
-description: Display aggregate details
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: aggregate.show
@@ -12,13 +12,26 @@ parameters:
         default: aggregate show
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('aggregate_show = openstackclient.compute.v2.aggregate:ShowAggregate')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
 runner_type: run-python

--- a/actions/aggregate.unset.yaml
+++ b/actions/aggregate.unset.yaml
@@ -1,0 +1,32 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: aggregate.unset
+parameters:
+    aggregate:
+        description: Aggregate to modify (name or ID)
+        required: true
+        type: string
+    base:
+        default: aggregate unset
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('aggregate_unset = openstackclient.compute.v2.aggregate:UnsetAggregate')
+        immutable: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    property:
+        description: Property to remove from aggregate (repeat option to remove multiple
+            properties)
+        type: array
+runner_type: run-python

--- a/actions/availability.zone.list.yaml
+++ b/actions/availability.zone.list.yaml
@@ -1,5 +1,5 @@
 ---
-description: List availability zones and their status
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: availability.zone.list
@@ -8,17 +8,42 @@ parameters:
         default: availability zone list
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    compute:
+        default: false
+        description: List compute availability zones
+        type: boolean
     ep:
-        default: EntryPoint.parse('availability_zone_list = openstackclient.compute.v2.availability_zone:ListAvailabilityZone')
+        default: EntryPoint.parse('availability_zone_list = openstackclient.common.availability_zone:ListAvailabilityZone')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: csv, html, json,
-            table, yaml)'
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
         type: string
     long:
         default: false
         description: List additional fields in output
+        type: boolean
+    network:
+        default: false
+        description: List network availability zones
+        type: boolean
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    volume:
+        default: false
+        description: List volume availability zones
         type: boolean
 runner_type: run-python

--- a/actions/backup.create.yaml
+++ b/actions/backup.create.yaml
@@ -1,5 +1,5 @@
 ---
-description: Create new backup
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: backup.create
@@ -8,6 +8,9 @@ parameters:
         default: backup create
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     container:
         description: Optional backup container name
         type: string
@@ -15,16 +18,37 @@ parameters:
         description: Description of the backup
         type: string
     ep:
-        default: EntryPoint.parse('backup_create = openstackclient.volume.v1.backup:CreateBackup')
+        default: EntryPoint.parse('backup_create = openstackclient.volume.v2.backup:CreateBackup')
         immutable: true
         type: string
+    force:
+        default: false
+        description: Allow to back up an in-use volume
+        type: boolean
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
         type: string
+    incremental:
+        default: false
+        description: Perform an incremental backup
+        type: boolean
     name:
         description: Name of the backup
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    snapshot:
+        description: Snapshot to backup (name or ID)
         type: string
     volume:
         description: Volume to backup (name or ID)

--- a/actions/backup.delete.yaml
+++ b/actions/backup.delete.yaml
@@ -1,19 +1,32 @@
 ---
-description: Delete backup(s)
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: backup.delete
 parameters:
     backups:
-        description: Backup(s) to delete (ID only)
+        description: Backup(s) to delete (name or ID)
         required: true
         type: string
     base:
         default: backup delete
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
-        default: EntryPoint.parse('backup_delete = openstackclient.volume.v1.backup:DeleteBackup')
+        default: EntryPoint.parse('backup_delete = openstackclient.volume.v2.backup:DeleteBackup')
         immutable: true
+        type: string
+    force:
+        default: false
+        description: Allow delete in state other than error or available
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
 runner_type: run-python

--- a/actions/backup.list.yaml
+++ b/actions/backup.list.yaml
@@ -1,24 +1,58 @@
 ---
-description: List backups
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: backup.list
 parameters:
+    all_projects:
+        default: false
+        description: Include all projects (admin only)
+        type: boolean
     base:
         default: backup list
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
-        default: EntryPoint.parse('backup_list = openstackclient.volume.v1.backup:ListBackup')
+        default: EntryPoint.parse('backup_list = openstackclient.volume.v2.backup:ListBackup')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: csv, html, json,
-            table, yaml)'
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
         type: string
+    limit:
+        description: Maximum number of backups to display
+        type: integer
     long:
         default: false
         description: List additional fields in output
         type: boolean
+    marker:
+        description: The last backup of the previous page (name or ID)
+        type: string
+    name:
+        description: Filters results by the backup name
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    status:
+        description: 'Filters results by the backup status (''creating'', ''available'',
+            ''deleting'', ''error'', ''restoring'' or ''error_restoring'') (choices:
+            creating, available, deleting, error, restoring, error_restoring)'
+        type: string
+    volume:
+        description: Filters results by the volume which they backup (name or ID)
+        type: string
 runner_type: run-python

--- a/actions/backup.restore.yaml
+++ b/actions/backup.restore.yaml
@@ -1,20 +1,38 @@
 ---
-description: Restore backup
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: backup.restore
 parameters:
     backup:
-        description: Backup to restore (ID only)
+        description: Backup to restore (name or ID)
         required: true
         type: string
     base:
         default: backup restore
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
-        default: EntryPoint.parse('backup_restore = openstackclient.volume.v1.backup:RestoreBackup')
+        default: EntryPoint.parse('backup_restore = openstackclient.volume.v2.backup:RestoreBackup')
         immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: json, shell,
+            table, value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     volume:
         description: Volume to restore to (name or ID)

--- a/actions/backup.show.yaml
+++ b/actions/backup.show.yaml
@@ -1,24 +1,37 @@
 ---
-description: Display backup details
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: backup.show
 parameters:
     backup:
-        description: Backup to display (ID only)
+        description: Backup to display (name or ID)
         required: true
         type: string
     base:
         default: backup show
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
-        default: EntryPoint.parse('backup_show = openstackclient.volume.v1.backup:ShowBackup')
+        default: EntryPoint.parse('backup_show = openstackclient.volume.v2.backup:ShowBackup')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
 runner_type: run-python

--- a/actions/catalog.list.yaml
+++ b/actions/catalog.list.yaml
@@ -1,5 +1,5 @@
 ---
-description: List services in the service catalog
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: catalog.list
@@ -8,13 +8,26 @@ parameters:
         default: catalog list
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('catalog_list = openstackclient.identity.v2_0.catalog:ListCatalog')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: csv, html, json,
-            table, yaml)'
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
 runner_type: run-python

--- a/actions/catalog.show.yaml
+++ b/actions/catalog.show.yaml
@@ -1,5 +1,5 @@
 ---
-description: Display service catalog details
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: catalog.show
@@ -8,14 +8,27 @@ parameters:
         default: catalog show
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('catalog_show = openstackclient.identity.v2_0.catalog:ShowCatalog')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     service:
         description: Service to display (type or name)

--- a/actions/command.list.yaml
+++ b/actions/command.list.yaml
@@ -1,5 +1,5 @@
 ---
-description: List recognized commands by group
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: command.list
@@ -8,13 +8,26 @@ parameters:
         default: command list
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('command_list = openstackclient.common.module:ListCommand')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: csv, html, json,
-            table, yaml)'
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
 runner_type: run-python

--- a/actions/complete.yaml
+++ b/actions/complete.yaml
@@ -8,12 +8,21 @@ parameters:
         default: complete
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
-        default: <cliff.commandmanager.EntryPointWrapper object at 0x7f6f3d3f8350>
+        default: <cliff.commandmanager.EntryPointWrapper object at 0x7f59cfc1f690>
         immutable: true
         type: string
     name:
         description: Command name to support with command completion
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     shell:
         default: bash

--- a/actions/compute.agent.create.yaml
+++ b/actions/compute.agent.create.yaml
@@ -1,5 +1,5 @@
 ---
-description: Create compute agent command
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: compute.agent.create
@@ -12,13 +12,16 @@ parameters:
         default: compute agent create
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('compute_agent_create = openstackclient.compute.v2.agent:CreateAgent')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
         type: string
     hypervisor:
@@ -30,9 +33,19 @@ parameters:
         description: MD5 hash
         required: true
         type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
     os:
         description: Type of OS
         required: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     url:
         description: URL

--- a/actions/compute.agent.delete.yaml
+++ b/actions/compute.agent.delete.yaml
@@ -1,5 +1,5 @@
 ---
-description: Delete compute agent command
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: compute.agent.delete
@@ -8,12 +8,21 @@ parameters:
         default: compute agent delete
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('compute_agent_delete = openstackclient.compute.v2.agent:DeleteAgent')
         immutable: true
         type: string
     id:
-        description: ID of agent to delete
+        description: ID of agent(s) to delete
         required: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
 runner_type: run-python

--- a/actions/compute.agent.list.yaml
+++ b/actions/compute.agent.list.yaml
@@ -1,5 +1,5 @@
 ---
-description: List compute agent command
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: compute.agent.list
@@ -8,16 +8,29 @@ parameters:
         default: compute agent list
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('compute_agent_list = openstackclient.compute.v2.agent:ListAgent')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: csv, html, json,
-            table, yaml)'
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
         type: string
     hypervisor:
         description: Type of hypervisor
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
 runner_type: run-python

--- a/actions/compute.agent.set.yaml
+++ b/actions/compute.agent.set.yaml
@@ -1,36 +1,37 @@
 ---
-description: Set compute agent command
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: compute.agent.set
 parameters:
+    agent_version:
+        description: Version of the agent
+        type: string
     base:
         default: compute agent set
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('compute_agent_set = openstackclient.compute.v2.agent:SetAgent')
         immutable: true
-        type: string
-    format:
-        default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
-            table, value, yaml)'
         type: string
     id:
         description: ID of the agent
         required: true
         type: string
     md5hash:
-        description: MD5 hash
-        required: true
+        description: MD5 hash of the agent
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     url:
-        description: URL
-        required: true
-        type: string
-    version:
-        description: Version of the agent
-        required: true
+        description: URL of the agent
         type: string
 runner_type: run-python

--- a/actions/compute.service.delete.yaml
+++ b/actions/compute.service.delete.yaml
@@ -1,0 +1,28 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: compute.service.delete
+parameters:
+    base:
+        default: compute service delete
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('compute_service_delete = openstackclient.compute.v2.service:DeleteService')
+        immutable: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    service:
+        description: Compute service(s) to delete (ID only)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/compute.service.list.yaml
+++ b/actions/compute.service.list.yaml
@@ -1,5 +1,5 @@
 ---
-description: List service command
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: compute.service.list
@@ -8,19 +8,36 @@ parameters:
         default: compute service list
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('compute_service_list = openstackclient.compute.v2.service:ListService')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: csv, html, json,
-            table, yaml)'
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
         type: string
     host:
-        description: Name of host
+        description: List services on specified host (name only)
+        type: string
+    long:
+        default: false
+        description: List additional fields in output
+        type: boolean
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     service:
-        description: Name of service
+        description: List only specified service (name only)
         type: string
 runner_type: run-python

--- a/actions/compute.service.set.yaml
+++ b/actions/compute.service.set.yaml
@@ -1,5 +1,5 @@
 ---
-description: Set service command
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: compute.service.set
@@ -8,29 +8,45 @@ parameters:
         default: compute service set
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     disable:
-        default: true
-        description: Disable a service
+        default: false
+        description: Disable service
+        type: boolean
+    disable_reason:
+        description: Reason for disabling the service (in quotas). Should be used
+            with --disable option.
+        type: string
+    down:
+        default: false
+        description: Force down service
         type: boolean
     enable:
-        default: true
-        description: Enable a service
+        default: false
+        description: Enable service
         type: boolean
     ep:
         default: EntryPoint.parse('compute_service_set = openstackclient.compute.v2.service:SetService')
         immutable: true
         type: string
-    format:
-        default: json
-        description: 'the output format, defaults to table (choices: csv, html, json,
-            table, yaml)'
-        type: string
     host:
         description: Name of host
         required: true
         type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
     service:
-        description: Name of service
+        description: Name of service (Binary name)
         required: true
         type: string
+    up:
+        default: false
+        description: Force up service
+        type: boolean
 runner_type: run-python

--- a/actions/configuration.show.yaml
+++ b/actions/configuration.show.yaml
@@ -1,0 +1,41 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: configuration.show
+parameters:
+    base:
+        default: configuration show
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('configuration_show = openstackclient.common.configuration:ShowConfiguration')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: json, shell,
+            table, value, yaml)'
+        type: string
+    mask:
+        default: true
+        description: Attempt to mask passwords (default)
+        type: boolean
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    unmask:
+        default: true
+        description: Show password in clear text
+        type: boolean
+runner_type: run-python

--- a/actions/consistency.group.create.yaml
+++ b/actions/consistency.group.create.yaml
@@ -1,0 +1,52 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: consistency.group.create
+parameters:
+    availability_zone:
+        description: Availability zone for this consistency group (not available if
+            creating consistency group from source)
+        type: string
+    base:
+        default: consistency group create
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    consistency_group_snapshot:
+        description: Existing consistency group snapshot (name or ID)
+        type: string
+    consistency_group_source:
+        description: Existing consistency group (name or ID)
+        type: string
+    description:
+        description: Description of this consistency group
+        type: string
+    ep:
+        default: EntryPoint.parse('consistency_group_create = openstackclient.volume.v2.consistency_group:CreateConsistencyGroup')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: json, shell,
+            table, value, yaml)'
+        type: string
+    name:
+        description: Name of new consistency group (default to None)
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    volume_type:
+        description: Volume type of this consistency group (name or ID)
+        type: string
+runner_type: run-python

--- a/actions/consistency.group.delete.yaml
+++ b/actions/consistency.group.delete.yaml
@@ -1,0 +1,32 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: consistency.group.delete
+parameters:
+    base:
+        default: consistency group delete
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    consistency_groups:
+        description: Consistency group(s) to delete (name or ID)
+        required: true
+        type: string
+    ep:
+        default: EntryPoint.parse('consistency_group_delete = openstackclient.volume.v2.consistency_group:DeleteConsistencyGroup')
+        immutable: true
+        type: string
+    force:
+        default: false
+        description: Allow delete in state other than error or available
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+runner_type: run-python

--- a/actions/consistency.group.list.yaml
+++ b/actions/consistency.group.list.yaml
@@ -1,0 +1,41 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: consistency.group.list
+parameters:
+    all_projects:
+        default: false
+        description: Show details for all projects. Admin only. (defaults to False)
+        type: boolean
+    base:
+        default: consistency group list
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('consistency_group_list = openstackclient.volume.v2.consistency_group:ListConsistencyGroup')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
+        type: string
+    long:
+        default: false
+        description: List additional fields in output
+        type: boolean
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+runner_type: run-python

--- a/actions/consistency.group.set.yaml
+++ b/actions/consistency.group.set.yaml
@@ -1,0 +1,34 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: consistency.group.set
+parameters:
+    base:
+        default: consistency group set
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    consistency_group:
+        description: Consistency group to modify (name or ID)
+        required: true
+        type: string
+    description:
+        description: New consistency group description
+        type: string
+    ep:
+        default: EntryPoint.parse('consistency_group_set = openstackclient.volume.v2.consistency_group:SetConsistencyGroup')
+        immutable: true
+        type: string
+    name:
+        description: New consistency group name
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+runner_type: run-python

--- a/actions/consistency.group.show.yaml
+++ b/actions/consistency.group.show.yaml
@@ -1,0 +1,37 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: consistency.group.show
+parameters:
+    base:
+        default: consistency group show
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    consistency_group:
+        description: Consistency group to display (name or ID)
+        required: true
+        type: string
+    ep:
+        default: EntryPoint.parse('consistency_group_show = openstackclient.volume.v2.consistency_group:ShowConsistencyGroup')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: json, shell,
+            table, value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+runner_type: run-python

--- a/actions/consistency.group.snapshot.create.yaml
+++ b/actions/consistency.group.snapshot.create.yaml
@@ -1,0 +1,43 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: consistency.group.snapshot.create
+parameters:
+    base:
+        default: consistency group snapshot create
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    consistency_group:
+        description: Consistency group to snapshot (name or ID) (default to be the
+            same as <snapshot-name>)
+        type: string
+    description:
+        description: Description of this consistency group snapshot
+        type: string
+    ep:
+        default: EntryPoint.parse('consistency_group_snapshot_create = openstackclient.volume.v2.consistency_group_snapshot:CreateConsistencyGroupSnapshot')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: json, shell,
+            table, value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    snapshot_name:
+        description: Name of new consistency group snapshot (default to None)
+        type: string
+runner_type: run-python

--- a/actions/consistency.group.snapshot.delete.yaml
+++ b/actions/consistency.group.snapshot.delete.yaml
@@ -1,0 +1,28 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: consistency.group.snapshot.delete
+parameters:
+    base:
+        default: consistency group snapshot delete
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    consistency_group_snapshot:
+        description: Consistency group snapshot(s) to delete (name or ID)
+        required: true
+        type: string
+    ep:
+        default: EntryPoint.parse('consistency_group_snapshot_delete = openstackclient.volume.v2.consistency_group_snapshot:DeleteConsistencyGroupSnapshot')
+        immutable: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+runner_type: run-python

--- a/actions/consistency.group.snapshot.list.yaml
+++ b/actions/consistency.group.snapshot.list.yaml
@@ -1,0 +1,49 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: consistency.group.snapshot.list
+parameters:
+    all_projects:
+        default: false
+        description: Show detail for all projects (admin only) (defaults to False)
+        type: boolean
+    base:
+        default: consistency group snapshot list
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    consistency_group:
+        description: Filters results by a consistency group (name or ID)
+        type: string
+    ep:
+        default: EntryPoint.parse('consistency_group_snapshot_list = openstackclient.volume.v2.consistency_group_snapshot:ListConsistencyGroupSnapshot')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
+        type: string
+    long:
+        default: false
+        description: List additional fields in output
+        type: boolean
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    status:
+        description: 'Filters results by a status ("available", "error", "creating",
+            "deleting" or "error_deleting") (choices: available, error, creating,
+            deleting, error-deleting)'
+        type: string
+runner_type: run-python

--- a/actions/consistency.group.snapshot.show.yaml
+++ b/actions/consistency.group.snapshot.show.yaml
@@ -1,0 +1,37 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: consistency.group.snapshot.show
+parameters:
+    base:
+        default: consistency group snapshot show
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    consistency_group_snapshot:
+        description: Consistency group snapshot to display (name or ID)
+        required: true
+        type: string
+    ep:
+        default: EntryPoint.parse('consistency_group_snapshot_show = openstackclient.volume.v2.consistency_group_snapshot:ShowConsistencyGroupSnapshot')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: json, shell,
+            table, value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+runner_type: run-python

--- a/actions/console.log.show.yaml
+++ b/actions/console.log.show.yaml
@@ -1,5 +1,5 @@
 ---
-description: Show server's console output
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: console.log.show
@@ -8,6 +8,9 @@ parameters:
         default: console log show
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('console_log_show = openstackclient.compute.v2.console:ShowConsoleLog')
         immutable: true
@@ -15,6 +18,12 @@ parameters:
     lines:
         description: Number of lines to display from the end of the log (default=all)
         type: integer
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
     server:
         description: Server to show console log (name or ID)
         required: true

--- a/actions/console.url.show.yaml
+++ b/actions/console.url.show.yaml
@@ -1,5 +1,5 @@
 ---
-description: Show server's remote console URL
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: console.url.show
@@ -8,18 +8,40 @@ parameters:
         default: console url show
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('console_url_show = openstackclient.compute.v2.console:ShowConsoleURL')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
         type: string
+    mks:
+        description: Show WebMKS console URL
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
     novnc:
         default: novnc
         description: Show noVNC console URL (default)
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    rdp:
+        description: Show RDP console URL
+        type: string
+    serial:
+        description: Show serial console URL
         type: string
     server:
         description: Server to show URL (name or ID)
@@ -29,6 +51,6 @@ parameters:
         description: Show SPICE console URL
         type: string
     xvpvnc:
-        description: Show xpvnc console URL
+        description: Show xvpvnc console URL
         type: string
 runner_type: run-python

--- a/actions/container.create.yaml
+++ b/actions/container.create.yaml
@@ -1,5 +1,5 @@
 ---
-description: Create new container
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: container.create
@@ -7,6 +7,9 @@ parameters:
     base:
         default: container create
         immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
         type: string
     containers:
         description: New container name(s)
@@ -18,7 +21,17 @@ parameters:
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: csv, html, json,
-            table, yaml)'
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
 runner_type: run-python

--- a/actions/container.delete.yaml
+++ b/actions/container.delete.yaml
@@ -1,5 +1,5 @@
 ---
-description: Delete container
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: container.delete
@@ -7,6 +7,9 @@ parameters:
     base:
         default: container delete
         immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
         type: string
     containers:
         description: Container(s) to delete
@@ -16,4 +19,14 @@ parameters:
         default: EntryPoint.parse('container_delete = openstackclient.object.v1.container:DeleteContainer')
         immutable: true
         type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    recursive:
+        default: false
+        description: Recursively delete objects and container
+        type: boolean
 runner_type: run-python

--- a/actions/container.list.yaml
+++ b/actions/container.list.yaml
@@ -1,5 +1,5 @@
 ---
-description: List containers
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: container.list
@@ -12,6 +12,9 @@ parameters:
         default: container list
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     end_marker:
         description: End anchor for paging
         type: string
@@ -21,8 +24,8 @@ parameters:
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: csv, html, json,
-            table, yaml)'
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
         type: string
     limit:
         description: Limit the number of containers returned
@@ -34,7 +37,17 @@ parameters:
     marker:
         description: Anchor for paging
         type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
     prefix:
         description: Filter list using <prefix>
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
 runner_type: run-python

--- a/actions/container.save.yaml
+++ b/actions/container.save.yaml
@@ -1,5 +1,5 @@
 ---
-description: Save container contents locally
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: container.save
@@ -8,6 +8,9 @@ parameters:
         default: container save
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     container:
         description: Container to save
         required: true
@@ -15,5 +18,11 @@ parameters:
     ep:
         default: EntryPoint.parse('container_save = openstackclient.object.v1.container:SaveContainer')
         immutable: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
 runner_type: run-python

--- a/actions/container.set.yaml
+++ b/actions/container.set.yaml
@@ -1,0 +1,33 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: container.set
+parameters:
+    base:
+        default: container set
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    container:
+        description: Container to modify
+        required: true
+        type: string
+    ep:
+        default: EntryPoint.parse('container_set = openstackclient.object.v1.container:SetContainer')
+        immutable: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    property:
+        description: Set a property on this container (repeat option to set multiple
+            properties)
+        required: true
+        type: array
+runner_type: run-python

--- a/actions/container.show.yaml
+++ b/actions/container.show.yaml
@@ -1,5 +1,5 @@
 ---
-description: Display container details
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: container.show
@@ -7,6 +7,9 @@ parameters:
     base:
         default: container show
         immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
         type: string
     container:
         description: Container to display
@@ -18,7 +21,17 @@ parameters:
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
 runner_type: run-python

--- a/actions/container.unset.yaml
+++ b/actions/container.unset.yaml
@@ -1,0 +1,34 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: container.unset
+parameters:
+    base:
+        default: container unset
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    container:
+        description: Container to modify
+        required: true
+        type: string
+    ep:
+        default: EntryPoint.parse('container_unset = openstackclient.object.v1.container:UnsetContainer')
+        immutable: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    property:
+        default: []
+        description: Property to remove from container (repeat option to remove multiple
+            properties)
+        required: true
+        type: array
+runner_type: run-python

--- a/actions/ec2.credentials.create.yaml
+++ b/actions/ec2.credentials.create.yaml
@@ -1,5 +1,5 @@
 ---
-description: Create EC2 credentials
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: ec2.credentials.create
@@ -8,20 +8,34 @@ parameters:
         default: ec2 credentials create
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('ec2_credentials_create = openstackclient.identity.v2_0.ec2creds:CreateEC2Creds')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
         type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
     project:
-        description: 'Specify an alternate project (default: current authenticated
-            project)'
+        description: 'Create credentials in project (name or ID; default: current
+            authenticated project)'
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     user:
-        description: 'Specify an alternate user (default: current authenticated user)'
+        description: 'Create credentials for user (name or ID; default: current authenticated
+            user)'
         type: string
 runner_type: run-python

--- a/actions/ec2.credentials.delete.yaml
+++ b/actions/ec2.credentials.delete.yaml
@@ -1,22 +1,31 @@
 ---
-description: Delete EC2 credentials
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: ec2.credentials.delete
 parameters:
-    access_key:
-        description: Credentials access key
+    access_keys:
+        description: Credentials access key(s)
         required: true
         type: string
     base:
         default: ec2 credentials delete
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('ec2_credentials_delete = openstackclient.identity.v2_0.ec2creds:DeleteEC2Creds')
         immutable: true
         type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
     user:
-        description: Specify a user
+        description: Delete credentials for user (name or ID)
         type: string
 runner_type: run-python

--- a/actions/ec2.credentials.list.yaml
+++ b/actions/ec2.credentials.list.yaml
@@ -1,5 +1,5 @@
 ---
-description: List EC2 credentials
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: ec2.credentials.list
@@ -8,16 +8,29 @@ parameters:
         default: ec2 credentials list
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('ec2_credentials_list = openstackclient.identity.v2_0.ec2creds:ListEC2Creds')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: csv, html, json,
-            table, yaml)'
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     user:
-        description: Specify a user
+        description: Filter list by user (name or ID)
         type: string
 runner_type: run-python

--- a/actions/ec2.credentials.show.yaml
+++ b/actions/ec2.credentials.show.yaml
@@ -1,5 +1,5 @@
 ---
-description: Display EC2 credentials details
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: ec2.credentials.show
@@ -12,16 +12,29 @@ parameters:
         default: ec2 credentials show
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('ec2_credentials_show = openstackclient.identity.v2_0.ec2creds:ShowEC2Creds')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
         type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
     user:
-        description: Specify a user
+        description: Show credentials for user (name or ID)
         type: string
 runner_type: run-python

--- a/actions/endpoint.create.yaml
+++ b/actions/endpoint.create.yaml
@@ -1,5 +1,5 @@
 ---
-description: Create new endpoint
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: endpoint.create
@@ -11,17 +11,30 @@ parameters:
         default: endpoint create
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('endpoint_create = openstackclient.identity.v2_0.endpoint:CreateEndpoint')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
         type: string
     internalurl:
         description: New endpoint internal URL
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     publicurl:
         description: New endpoint public URL (required)
@@ -31,7 +44,7 @@ parameters:
         description: New endpoint region ID
         type: string
     service:
-        description: New endpoint service (name or ID)
+        description: Service to be associated with new endpoint (name or ID)
         required: true
         type: string
 runner_type: run-python

--- a/actions/endpoint.delete.yaml
+++ b/actions/endpoint.delete.yaml
@@ -1,5 +1,5 @@
 ---
-description: Delete endpoint
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: endpoint.delete
@@ -8,12 +8,21 @@ parameters:
         default: endpoint delete
         immutable: true
         type: string
-    endpoint:
-        description: Endpoint ID to delete
+    cloud:
+        description: A specific cloud to query
+        type: string
+    endpoints:
+        description: Endpoint(s) to delete (ID only)
         required: true
         type: string
     ep:
         default: EntryPoint.parse('endpoint_delete = openstackclient.identity.v2_0.endpoint:DeleteEndpoint')
         immutable: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
 runner_type: run-python

--- a/actions/endpoint.list.yaml
+++ b/actions/endpoint.list.yaml
@@ -1,5 +1,5 @@
 ---
-description: List endpoints
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: endpoint.list
@@ -8,17 +8,30 @@ parameters:
         default: endpoint list
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('endpoint_list = openstackclient.identity.v2_0.endpoint:ListEndpoint')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: csv, html, json,
-            table, yaml)'
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
         type: string
     long:
         default: false
         description: List additional fields in output
         type: boolean
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
 runner_type: run-python

--- a/actions/endpoint.show.yaml
+++ b/actions/endpoint.show.yaml
@@ -1,5 +1,5 @@
 ---
-description: Display endpoint details
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: endpoint.show
@@ -8,8 +8,12 @@ parameters:
         default: endpoint show
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     endpoint_or_service:
-        description: Endpoint ID to display
+        description: Endpoint to display (endpoint ID, service ID, service name, service
+            type)
         required: true
         type: string
     ep:
@@ -18,7 +22,17 @@ parameters:
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
 runner_type: run-python

--- a/actions/extension.list.yaml
+++ b/actions/extension.list.yaml
@@ -1,5 +1,5 @@
 ---
-description: List API extensions
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: extension.list
@@ -7,6 +7,9 @@ parameters:
     base:
         default: extension list
         immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
         type: string
     compute:
         default: false
@@ -18,8 +21,8 @@ parameters:
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: csv, html, json,
-            table, yaml)'
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
         type: string
     identity:
         default: false
@@ -33,8 +36,18 @@ parameters:
         default: false
         description: List extensions for the Network API
         type: boolean
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
     volume:
         default: false
-        description: List extensions for the Volume API
+        description: List extensions for the Block Storage API
         type: boolean
 runner_type: run-python

--- a/actions/flavor.create.yaml
+++ b/actions/flavor.create.yaml
@@ -1,5 +1,5 @@
 ---
-description: Create new flavor
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: flavor.create
@@ -7,6 +7,9 @@ parameters:
     base:
         default: flavor create
         immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
         type: string
     disk:
         default: 0
@@ -22,7 +25,7 @@ parameters:
         type: integer
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
         type: string
     id:
@@ -33,10 +36,32 @@ parameters:
         description: New flavor name
         required: true
         type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
     private:
         default: true
         description: Flavor is not available to other projects
         type: boolean
+    project:
+        description: Allow <project> to access private flavor (name or ID) (Must be
+            used with --private option)
+        type: string
+    project_domain:
+        description: Domain the project belongs to (name or ID). This can be used
+            in case collisions between project names exist.
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    property:
+        description: Property to add for this flavor (repeat option to set multiple
+            properties)
+        type: array
     public:
         default: true
         description: Flavor is available to other projects (default)
@@ -46,9 +71,9 @@ parameters:
         description: Memory size in MB (default 256M)
         type: integer
     rxtx_factor:
-        default: 1
-        description: RX/TX factor (default 1)
-        type: integer
+        default: 1.0
+        description: RX/TX factor (default 1.0)
+        type: number
     swap:
         default: 0
         description: Swap space size in GB (default 0G)

--- a/actions/flavor.delete.yaml
+++ b/actions/flavor.delete.yaml
@@ -1,5 +1,5 @@
 ---
-description: Delete flavor
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: flavor.delete
@@ -8,12 +8,21 @@ parameters:
         default: flavor delete
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('flavor_delete = openstackclient.compute.v2.flavor:DeleteFlavor')
         immutable: true
         type: string
     flavor:
-        description: Flavor to delete (name or ID)
+        description: Flavor(s) to delete (name or ID)
         required: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
 runner_type: run-python

--- a/actions/flavor.list.yaml
+++ b/actions/flavor.list.yaml
@@ -1,5 +1,5 @@
 ---
-description: List flavors
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: flavor.list
@@ -12,23 +12,42 @@ parameters:
         default: flavor list
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('flavor_list = openstackclient.compute.v2.flavor:ListFlavor')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: csv, html, json,
-            table, yaml)'
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
         type: string
+    limit:
+        description: Maximum number of flavors to display
+        type: integer
     long:
         default: false
         description: List additional fields in output
+        type: boolean
+    marker:
+        description: The last flavor ID of the previous page
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
         type: boolean
     private:
         default: true
         description: List only private flavors
         type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
     public:
         default: true
         description: List only public flavors (default)

--- a/actions/flavor.set.yaml
+++ b/actions/flavor.set.yaml
@@ -1,5 +1,5 @@
 ---
-description: Set flavor properties
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: flavor.set
@@ -7,6 +7,9 @@ parameters:
     base:
         default: flavor set
         immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
         type: string
     ep:
         default: EntryPoint.parse('flavor_set = openstackclient.compute.v2.flavor:SetFlavor')
@@ -16,10 +19,18 @@ parameters:
         description: Flavor to modify (name or ID)
         required: true
         type: string
-    format:
-        default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
-            table, value, yaml)'
+    project:
+        description: Set flavor access to project (name or ID) (admin only)
+        type: string
+    project_domain:
+        description: Domain the project belongs to (name or ID). This can be used
+            in case collisions between project names exist.
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     property:
         description: Property to add or modify for this flavor (repeat option to set

--- a/actions/flavor.show.yaml
+++ b/actions/flavor.show.yaml
@@ -1,5 +1,5 @@
 ---
-description: Display flavor details
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: flavor.show
@@ -7,6 +7,9 @@ parameters:
     base:
         default: flavor show
         immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
         type: string
     ep:
         default: EntryPoint.parse('flavor_show = openstackclient.compute.v2.flavor:ShowFlavor')
@@ -18,7 +21,17 @@ parameters:
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
 runner_type: run-python

--- a/actions/flavor.unset.yaml
+++ b/actions/flavor.unset.yaml
@@ -1,5 +1,5 @@
 ---
-description: Unset flavor properties
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: flavor.unset
@@ -7,6 +7,9 @@ parameters:
     base:
         default: flavor unset
         immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
         type: string
     ep:
         default: EntryPoint.parse('flavor_unset = openstackclient.compute.v2.flavor:UnsetFlavor')
@@ -16,10 +19,18 @@ parameters:
         description: Flavor to modify (name or ID)
         required: true
         type: string
-    format:
-        default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
-            table, value, yaml)'
+    project:
+        description: Remove flavor access from project (name or ID) (admin only)
+        type: string
+    project_domain:
+        description: Domain the project belongs to (name or ID). This can be used
+            in case collisions between project names exist.
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     property:
         description: Property to remove from flavor (repeat option to unset multiple

--- a/actions/help.yaml
+++ b/actions/help.yaml
@@ -8,12 +8,21 @@ parameters:
         default: help
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     cmd:
         description: name of the command
         required: true
         type: string
     ep:
-        default: <cliff.commandmanager.EntryPointWrapper object at 0x7f6f3d3f8310>
+        default: <cliff.commandmanager.EntryPointWrapper object at 0x7f59cfc1fa50>
         immutable: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
 runner_type: run-python

--- a/actions/host.list.yaml
+++ b/actions/host.list.yaml
@@ -1,5 +1,5 @@
 ---
-description: List host command
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: host.list
@@ -8,16 +8,29 @@ parameters:
         default: host list
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('host_list = openstackclient.compute.v2.host:ListHost')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: csv, html, json,
-            table, yaml)'
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     zone:
-        description: Only return hosts in the availability zone.
+        description: Only return hosts in the availability zone
         type: string
 runner_type: run-python

--- a/actions/host.set.yaml
+++ b/actions/host.set.yaml
@@ -1,0 +1,44 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: host.set
+parameters:
+    base:
+        default: host set
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    disable:
+        default: false
+        description: Disable the host
+        type: boolean
+    disable_maintenance:
+        default: false
+        description: Disable maintenance mode for the host
+        type: boolean
+    enable:
+        default: false
+        description: Enable the host
+        type: boolean
+    enable_maintenance:
+        default: false
+        description: Enable maintenance mode for the host
+        type: boolean
+    ep:
+        default: EntryPoint.parse('host_set = openstackclient.compute.v2.host:SetHost')
+        immutable: true
+        type: string
+    host:
+        description: Host to modify (name only)
+        required: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+runner_type: run-python

--- a/actions/host.show.yaml
+++ b/actions/host.show.yaml
@@ -1,5 +1,5 @@
 ---
-description: Show host command
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: host.show
@@ -8,17 +8,30 @@ parameters:
         default: host show
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('host_show = openstackclient.compute.v2.host:ShowHost')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: csv, html, json,
-            table, yaml)'
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
         type: string
     host:
         description: Name of host
         required: true
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
 runner_type: run-python

--- a/actions/hypervisor.list.yaml
+++ b/actions/hypervisor.list.yaml
@@ -1,5 +1,5 @@
 ---
-description: List hypervisors
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: hypervisor.list
@@ -8,16 +8,33 @@ parameters:
         default: hypervisor list
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('hypervisor_list = openstackclient.compute.v2.hypervisor:ListHypervisor')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: csv, html, json,
-            table, yaml)'
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
         type: string
+    long:
+        default: false
+        description: List additional fields in output
+        type: boolean
     matching:
         description: Filter hypervisors using <hostname> substring
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
 runner_type: run-python

--- a/actions/hypervisor.show.yaml
+++ b/actions/hypervisor.show.yaml
@@ -1,5 +1,5 @@
 ---
-description: Display hypervisor details
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: hypervisor.show
@@ -8,17 +8,30 @@ parameters:
         default: hypervisor show
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('hypervisor_show = openstackclient.compute.v2.hypervisor:ShowHypervisor')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
         type: string
     hypervisor:
         description: Hypervisor to display (name or ID)
         required: true
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
 runner_type: run-python

--- a/actions/hypervisor.stats.show.yaml
+++ b/actions/hypervisor.stats.show.yaml
@@ -1,5 +1,5 @@
 ---
-description: Display hypervisor stats details
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: hypervisor.stats.show
@@ -8,13 +8,26 @@ parameters:
         default: hypervisor stats show
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('hypervisor_stats_show = openstackclient.compute.v2.hypervisor_stats:ShowHypervisorStats')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
 runner_type: run-python

--- a/actions/image.add.project.yaml
+++ b/actions/image.add.project.yaml
@@ -1,0 +1,45 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: image.add.project
+parameters:
+    base:
+        default: image add project
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('image_add_project = openstackclient.image.v2.image:AddProjectToImage')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: json, shell,
+            table, value, yaml)'
+        type: string
+    image:
+        description: Image to share (name or ID)
+        required: true
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project:
+        description: Project to associate with image (name or ID)
+        required: true
+        type: string
+    project_domain:
+        description: Domain the project belongs to (name or ID). This can be used
+            in case collisions between project names exist.
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+runner_type: run-python

--- a/actions/image.create.yaml
+++ b/actions/image.create.yaml
@@ -1,5 +1,5 @@
 ---
-description: Create/upload an image
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: image.create
@@ -9,21 +9,26 @@ parameters:
         immutable: true
         type: string
     checksum:
-        description: Image hash used for verification
+        description: ==SUPPRESS==
+        type: string
+    cloud:
+        description: A specific cloud to query
         type: string
     container_format:
         default: bare
         description: 'Image container format (default: bare)'
         type: string
     copy_from:
-        description: Copy image from the data store (similar to --location)
+        description: ==SUPPRESS==
         type: string
     disk_format:
         default: raw
-        description: 'Image disk format (default: raw)'
+        description: 'Image disk format. The supported options are: ami, ari, aki,
+            vhd, vmdk, raw, qcow2, vhdx, vdi, iso, ploop. The default format is: raw
+            (choices: ami, ari, aki, vhd, vmdk, raw, qcow2, vhdx, vdi, iso, ploop)'
         type: string
     ep:
-        default: EntryPoint.parse('image_create = openstackclient.image.v1.image:CreateImage')
+        default: EntryPoint.parse('image_create = openstackclient.image.v2.image:CreateImage')
         immutable: true
         type: string
     file:
@@ -36,14 +41,14 @@ parameters:
         type: boolean
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
         type: string
     id:
         description: Image ID to reserve
         type: string
     location:
-        description: Download image from an existing URL
+        description: ==SUPPRESS==
         type: string
     min_disk:
         description: Minimum disk size needed to boot image, in gigabytes
@@ -55,13 +60,30 @@ parameters:
         description: New image name
         required: true
         type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
     owner:
-        description: Image owner project name or ID
+        description: ==SUPPRESS==
         type: string
     private:
         default: false
         description: Image is inaccessible to the public (default)
         type: boolean
+    project:
+        description: Set an alternate project on this image (name or ID)
+        type: string
+    project_domain:
+        description: Domain the project belongs to (name or ID). This can be used
+            in case collisions between project names exist.
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
     property:
         description: Set a property on this image (repeat option to set multiple properties)
         type: array
@@ -74,11 +96,14 @@ parameters:
         description: Image is accessible to the public
         type: boolean
     size:
-        description: Image size, in bytes (only used with --location and --copy-from)
+        description: ==SUPPRESS==
         type: string
     store:
-        description: Upload image to this store
+        description: ==SUPPRESS==
         type: string
+    tag:
+        description: Set a tag on this image (repeat option to set multiple tags)
+        type: array
     unprotected:
         default: false
         description: Allow image to be deleted (default)

--- a/actions/image.delete.yaml
+++ b/actions/image.delete.yaml
@@ -1,5 +1,5 @@
 ---
-description: Delete image(s)
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: image.delete
@@ -8,12 +8,21 @@ parameters:
         default: image delete
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
-        default: EntryPoint.parse('image_delete = openstackclient.image.v1.image:DeleteImage')
+        default: EntryPoint.parse('image_delete = openstackclient.image.v2.image:DeleteImage')
         immutable: true
         type: string
     images:
         description: Image(s) to delete (name or ID)
         required: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
 runner_type: run-python

--- a/actions/image.list.yaml
+++ b/actions/image.list.yaml
@@ -1,5 +1,5 @@
 ---
-description: List available images
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: image.list
@@ -8,18 +8,32 @@ parameters:
         default: image list
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
-        default: EntryPoint.parse('image_list = openstackclient.image.v1.image:ListImage')
+        default: EntryPoint.parse('image_list = openstackclient.image.v2.image:ListImage')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: csv, html, json,
-            table, yaml)'
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
         type: string
+    limit:
+        description: Maximum number of images to display.
+        type: integer
     long:
         default: false
         description: List additional fields in output
+        type: boolean
+    marker:
+        description: The last image (name or ID) of the previous page. Display list
+            of images after marker. Display all images if not specified.
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
         type: boolean
     page_size:
         description: ==SUPPRESS==
@@ -28,6 +42,12 @@ parameters:
         default: false
         description: List only private images
         type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
     property:
         description: Filter output based on property
         type: array
@@ -37,10 +57,12 @@ parameters:
         type: boolean
     shared:
         default: false
-        description: ==SUPPRESS==
+        description: List only shared images
         type: boolean
     sort:
+        default: name:asc
         description: 'Sort output by selected keys and directions(asc or desc) (default:
-            asc), multiple keys and directions can be specified separated by comma'
+            name:asc), multiple keys and directions can be specified separated by
+            comma'
         type: string
 runner_type: run-python

--- a/actions/image.remove.project.yaml
+++ b/actions/image.remove.project.yaml
@@ -1,0 +1,36 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: image.remove.project
+parameters:
+    base:
+        default: image remove project
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('image_remove_project = openstackclient.image.v2.image:RemoveProjectImage')
+        immutable: true
+        type: string
+    image:
+        description: Image to unshare (name or ID)
+        required: true
+        type: string
+    project:
+        description: Project to disassociate with image (name or ID)
+        required: true
+        type: string
+    project_domain:
+        description: Domain the project belongs to (name or ID). This can be used
+            in case collisions between project names exist.
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+runner_type: run-python

--- a/actions/image.save.yaml
+++ b/actions/image.save.yaml
@@ -1,5 +1,5 @@
 ---
-description: Save an image locally
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: image.save
@@ -8,8 +8,11 @@ parameters:
         default: image save
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
-        default: EntryPoint.parse('image_save = openstackclient.image.v1.image:SaveImage')
+        default: EntryPoint.parse('image_save = openstackclient.image.v2.image:SaveImage')
         immutable: true
         type: string
     file:
@@ -18,5 +21,11 @@ parameters:
     image:
         description: Image to save (name or ID)
         required: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
 runner_type: run-python

--- a/actions/image.set.yaml
+++ b/actions/image.set.yaml
@@ -1,25 +1,51 @@
 ---
-description: Set image properties
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: image.set
 parameters:
+    activate:
+        default: false
+        description: Activate the image
+        type: boolean
+    architecture:
+        description: Operating system architecture
+        type: string
     base:
         default: image set
         immutable: true
         type: string
-    ep:
-        default: EntryPoint.parse('image_set = openstackclient.image.v1.image:SetImage')
-        immutable: true
+    cloud:
+        description: A specific cloud to query
         type: string
-    format:
-        default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
-            table, value, yaml)'
+    container_format:
+        description: 'Image container format (default: bare)'
+        type: string
+    deactivate:
+        default: false
+        description: Deactivate the image
+        type: boolean
+    disk_format:
+        description: 'Image disk format. The supported options are: ami, ari, aki,
+            vhd, vmdk, raw, qcow2, vhdx, vdi, iso, ploop (choices: ami, ari, aki,
+            vhd, vmdk, raw, qcow2, vhdx, vdi, iso, ploop)'
+        type: string
+    ep:
+        default: EntryPoint.parse('image_set = openstackclient.image.v2.image:SetImage')
+        immutable: true
         type: string
     image:
         description: Image to modify (name or ID)
         required: true
+        type: string
+    instance_id:
+        description: ID of server instance used to create this image
+        type: string
+    instance_uuid:
+        description: ==SUPPRESS==
+        type: string
+    kernel_id:
+        description: ID of kernel image used to boot this disk image
         type: string
     min_disk:
         description: Minimum disk size needed to boot image, in gigabytes
@@ -30,13 +56,32 @@ parameters:
     name:
         description: New image name
         type: string
+    os_distro:
+        description: Operating system distribution name
+        type: string
+    os_version:
+        description: Operating system distribution version
+        type: string
     owner:
-        description: New image owner project (name or ID)
+        description: ==SUPPRESS==
         type: string
     private:
         default: false
         description: Image is inaccessible to the public (default)
         type: boolean
+    project:
+        description: Set an alternate project on this image (name or ID)
+        type: string
+    project_domain:
+        description: Domain the project belongs to (name or ID). This can be used
+            in case collisions between project names exist.
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
     property:
         description: Set a property on this image (repeat option to set multiple properties)
         type: array
@@ -48,8 +93,18 @@ parameters:
         default: false
         description: Image is accessible to the public
         type: boolean
+    ramdisk_id:
+        description: ID of ramdisk image used to boot this disk image
+        type: string
+    tag:
+        default: []
+        description: Set a tag on this image (repeat option to set multiple tags)
+        type: array
     unprotected:
         default: false
         description: Allow image to be deleted (default)
         type: boolean
+    visibility:
+        description: ==SUPPRESS==
+        type: string
 runner_type: run-python

--- a/actions/image.show.yaml
+++ b/actions/image.show.yaml
@@ -1,5 +1,5 @@
 ---
-description: Display image details
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: image.show
@@ -8,17 +8,30 @@ parameters:
         default: image show
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
-        default: EntryPoint.parse('image_show = openstackclient.image.v1.image:ShowImage')
+        default: EntryPoint.parse('image_show = openstackclient.image.v2.image:ShowImage')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
         type: string
     image:
         description: Image to display (name or ID)
         required: true
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
 runner_type: run-python

--- a/actions/image.unset.yaml
+++ b/actions/image.unset.yaml
@@ -1,0 +1,37 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: image.unset
+parameters:
+    base:
+        default: image unset
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('image_unset = openstackclient.image.v2.image:UnsetImage')
+        immutable: true
+        type: string
+    image:
+        description: Image to modify (name or ID)
+        required: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    property:
+        default: []
+        description: Unset a property on this image (repeat option to set multiple
+            properties)
+        type: array
+    tag:
+        default: []
+        description: Unset a tag on this image (repeat option to set multiple tags)
+        type: array
+runner_type: run-python

--- a/actions/ip.availability.show.yaml
+++ b/actions/ip.availability.show.yaml
@@ -1,0 +1,37 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: ip.availability.show
+parameters:
+    base:
+        default: ip availability show
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('ip_availability_show = openstackclient.network.v2.ip_availability:ShowIPAvailability')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: json, shell,
+            table, value, yaml)'
+        type: string
+    network:
+        description: Show IP availability for a specific network (name or ID)
+        required: true
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+runner_type: run-python

--- a/actions/ip.fixed.add.yaml
+++ b/actions/ip.fixed.add.yaml
@@ -1,5 +1,5 @@
 ---
-description: Add fixed-ip command
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: ip.fixed.add
@@ -8,16 +8,25 @@ parameters:
         default: ip fixed add
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('ip_fixed_add = openstackclient.compute.v2.fixedip:AddFixedIP')
         immutable: true
         type: string
     network:
-        description: Name of the network to fetch an IP address from
+        description: Network to fetch an IP address from (name or ID)
         required: true
         type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
     server:
-        description: Name of the server to receive the IP address
+        description: Server to receive the IP address (name or ID)
         required: true
         type: string
 runner_type: run-python

--- a/actions/ip.fixed.remove.yaml
+++ b/actions/ip.fixed.remove.yaml
@@ -1,5 +1,5 @@
 ---
-description: Remove fixed-ip command
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: ip.fixed.remove
@@ -8,16 +8,25 @@ parameters:
         default: ip fixed remove
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('ip_fixed_remove = openstackclient.compute.v2.fixedip:RemoveFixedIP')
         immutable: true
         type: string
     ip_address:
-        description: IP address to remove from server
+        description: IP address to remove from server (name only)
         required: true
         type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
     server:
-        description: Name of the server to remove the IP address from
+        description: Server to remove the IP address from (name or ID)
         required: true
         type: string
 runner_type: run-python

--- a/actions/ip.floating.add.yaml
+++ b/actions/ip.floating.add.yaml
@@ -1,5 +1,5 @@
 ---
-description: Add floating-ip to server
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: ip.floating.add
@@ -8,13 +8,22 @@ parameters:
         default: ip floating add
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('ip_floating_add = openstackclient.compute.v2.floatingip:AddFloatingIP')
         immutable: true
         type: string
     ip_address:
-        description: IP address to add to server
+        description: IP address to add to server (name only)
         required: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     server:
         description: Server to receive the IP address (name or ID)

--- a/actions/ip.floating.remove.yaml
+++ b/actions/ip.floating.remove.yaml
@@ -1,5 +1,5 @@
 ---
-description: Remove floating-ip from server
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: ip.floating.remove
@@ -8,13 +8,22 @@ parameters:
         default: ip floating remove
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('ip_floating_remove = openstackclient.compute.v2.floatingip:RemoveFloatingIP')
         immutable: true
         type: string
     ip_address:
-        description: IP address to remove from server
+        description: IP address to remove from server (name only)
         required: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     server:
         description: Server to remove the IP address from (name or ID)

--- a/actions/keypair.create.yaml
+++ b/actions/keypair.create.yaml
@@ -1,5 +1,5 @@
 ---
-description: Create new public key
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: keypair.create
@@ -8,20 +8,34 @@ parameters:
         default: keypair create
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('keypair_create = openstackclient.compute.v2.keypair:CreateKeypair')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
         type: string
     name:
-        description: New public key name
+        description: New public or private key name
         required: true
         type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
     public_key:
-        description: Filename for public key to add
+        description: Filename for public key to add. If not used, creates a private
+            key.
         type: string
 runner_type: run-python

--- a/actions/keypair.delete.yaml
+++ b/actions/keypair.delete.yaml
@@ -1,5 +1,5 @@
 ---
-description: Delete public key
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: keypair.delete
@@ -8,12 +8,21 @@ parameters:
         default: keypair delete
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('keypair_delete = openstackclient.compute.v2.keypair:DeleteKeypair')
         immutable: true
         type: string
     name:
-        description: Public key to delete
+        description: Name of key(s) to delete (name only)
         required: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
 runner_type: run-python

--- a/actions/keypair.list.yaml
+++ b/actions/keypair.list.yaml
@@ -1,5 +1,5 @@
 ---
-description: List public key fingerprints
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: keypair.list
@@ -8,13 +8,26 @@ parameters:
         default: keypair list
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('keypair_list = openstackclient.compute.v2.keypair:ListKeypair')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: csv, html, json,
-            table, yaml)'
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
 runner_type: run-python

--- a/actions/keypair.show.yaml
+++ b/actions/keypair.show.yaml
@@ -1,5 +1,5 @@
 ---
-description: Display public key details
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: keypair.show
@@ -8,21 +8,34 @@ parameters:
         default: keypair show
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('keypair_show = openstackclient.compute.v2.keypair:ShowKeypair')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
         type: string
     name:
-        description: Public key to display
+        description: Public or private key to display (name only)
         required: true
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     public_key:
         default: false
-        description: Show only bare public key
+        description: Show only bare public key paired with the generated key
         type: boolean
 runner_type: run-python

--- a/actions/limits.show.yaml
+++ b/actions/limits.show.yaml
@@ -1,5 +1,5 @@
 ---
-description: Show compute and volume limits
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: limits.show
@@ -12,8 +12,11 @@ parameters:
         default: limits show
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     domain:
-        description: Domain that owns --project (name or ID)  [only valid with --absolute]
+        description: Domain the project belongs to (name or ID) [only valid with --absolute]
         type: string
     ep:
         default: EntryPoint.parse('limits_show = openstackclient.common.limits:ShowLimits')
@@ -21,12 +24,22 @@ parameters:
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: csv, html, json,
-            table, yaml)'
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
         type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
     project:
         description: Show limits for a specific project (name or ID) [only valid with
             --absolute]
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     rate:
         default: false

--- a/actions/module.list.yaml
+++ b/actions/module.list.yaml
@@ -1,5 +1,5 @@
 ---
-description: List module versions
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: module.list
@@ -12,13 +12,26 @@ parameters:
         default: module list
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('module_list = openstackclient.common.module:ListModule')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
 runner_type: run-python

--- a/actions/network.agent.delete.yaml
+++ b/actions/network.agent.delete.yaml
@@ -1,0 +1,28 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: network.agent.delete
+parameters:
+    base:
+        default: network agent delete
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('network_agent_delete = openstackclient.network.v2.network_agent:DeleteNetworkAgent')
+        immutable: true
+        type: string
+    network_agent:
+        description: Network agent(s) to delete (ID only)
+        required: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+runner_type: run-python

--- a/actions/network.agent.list.yaml
+++ b/actions/network.agent.list.yaml
@@ -1,0 +1,33 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: network.agent.list
+parameters:
+    base:
+        default: network agent list
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('network_agent_list = openstackclient.network.v2.network_agent:ListNetworkAgent')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+runner_type: run-python

--- a/actions/network.agent.set.yaml
+++ b/actions/network.agent.set.yaml
@@ -1,0 +1,39 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: network.agent.set
+parameters:
+    base:
+        default: network agent set
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    description:
+        description: Set network agent description
+        type: string
+    disable:
+        default: false
+        description: Disable network agent
+        type: boolean
+    enable:
+        default: false
+        description: Enable network agent
+        type: boolean
+    ep:
+        default: EntryPoint.parse('network_agent_set = openstackclient.network.v2.network_agent:SetNetworkAgent')
+        immutable: true
+        type: string
+    network_agent:
+        description: Network agent to modify (ID only)
+        required: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+runner_type: run-python

--- a/actions/network.agent.show.yaml
+++ b/actions/network.agent.show.yaml
@@ -1,0 +1,37 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: network.agent.show
+parameters:
+    base:
+        default: network agent show
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('network_agent_show = openstackclient.network.v2.network_agent:ShowNetworkAgent')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: json, shell,
+            table, value, yaml)'
+        type: string
+    network_agent:
+        description: Network agent to display (ID only)
+        required: true
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+runner_type: run-python

--- a/actions/network.qos.policy.create.yaml
+++ b/actions/network.qos.policy.create.yaml
@@ -1,0 +1,55 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: network.qos.policy.create
+parameters:
+    base:
+        default: network qos policy create
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    description:
+        description: Description of the QoS policy
+        type: string
+    ep:
+        default: EntryPoint.parse('network_qos_policy_create = openstackclient.network.v2.network_qos_policy:CreateNetworkQosPolicy')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: json, shell,
+            table, value, yaml)'
+        type: string
+    name:
+        description: Name of QoS policy to create
+        required: true
+        type: string
+    no_share:
+        default: false
+        description: Make the QoS policy not accessible by other projects (default)
+        type: boolean
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project:
+        description: Owner's project (name or ID)
+        type: string
+    project_domain:
+        description: Domain the project belongs to (name or ID). This can be used
+            in case collisions between project names exist.
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    share:
+        default: false
+        description: Make the QoS policy accessible by other projects
+        type: boolean
+runner_type: run-python

--- a/actions/network.qos.policy.delete.yaml
+++ b/actions/network.qos.policy.delete.yaml
@@ -1,0 +1,28 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: network.qos.policy.delete
+parameters:
+    base:
+        default: network qos policy delete
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('network_qos_policy_delete = openstackclient.network.v2.network_qos_policy:DeleteNetworkQosPolicy')
+        immutable: true
+        type: string
+    policy:
+        description: QoS policy(s) to delete (name or ID)
+        required: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+runner_type: run-python

--- a/actions/network.qos.policy.list.yaml
+++ b/actions/network.qos.policy.list.yaml
@@ -1,0 +1,33 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: network.qos.policy.list
+parameters:
+    base:
+        default: network qos policy list
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('network_qos_policy_list = openstackclient.network.v2.network_qos_policy:ListNetworkQosPolicy')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+runner_type: run-python

--- a/actions/network.qos.policy.set.yaml
+++ b/actions/network.qos.policy.set.yaml
@@ -1,0 +1,42 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: network.qos.policy.set
+parameters:
+    base:
+        default: network qos policy set
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    description:
+        description: Description of the QoS policy
+        type: string
+    ep:
+        default: EntryPoint.parse('network_qos_policy_set = openstackclient.network.v2.network_qos_policy:SetNetworkQosPolicy')
+        immutable: true
+        type: string
+    name:
+        description: Set QoS policy name
+        type: string
+    no_share:
+        default: false
+        description: Make the QoS policy not accessible by other projects
+        type: boolean
+    policy:
+        description: QoS policy to modify (name or ID)
+        required: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    share:
+        default: false
+        description: Make the QoS policy accessible by other projects
+        type: boolean
+runner_type: run-python

--- a/actions/network.qos.policy.show.yaml
+++ b/actions/network.qos.policy.show.yaml
@@ -1,0 +1,37 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: network.qos.policy.show
+parameters:
+    base:
+        default: network qos policy show
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('network_qos_policy_show = openstackclient.network.v2.network_qos_policy:ShowNetworkQosPolicy')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: json, shell,
+            table, value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    policy:
+        description: QoS policy to display (name or ID)
+        required: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+runner_type: run-python

--- a/actions/network.rbac.create.yaml
+++ b/actions/network.rbac.create.yaml
@@ -1,0 +1,63 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: network.rbac.create
+parameters:
+    action:
+        description: 'Action for the RBAC policy ("access_as_external" or "access_as_shared")
+            (choices: access_as_external, access_as_shared)'
+        required: true
+        type: string
+    base:
+        default: network rbac create
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('network_rbac_create = openstackclient.network.v2.network_rbac:CreateNetworkRBAC')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: json, shell,
+            table, value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project:
+        description: The owner project (name or ID)
+        type: string
+    project_domain:
+        description: Domain the project belongs to (name or ID). This can be used
+            in case collisions between project names exist.
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    rbac_object:
+        description: The object to which this RBAC policy affects (name or ID)
+        required: true
+        type: string
+    target_project:
+        description: The project to which the RBAC policy will be enforced (name or
+            ID)
+        required: true
+        type: string
+    target_project_domain:
+        description: Domain the target project belongs to (name or ID). This can be
+            used in case collisions between project names exist.
+        type: string
+    type:
+        description: 'Type of the object that RBAC policy affects ("qos_policy" or
+            "network") (choices: qos_policy, network)'
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/network.rbac.delete.yaml
+++ b/actions/network.rbac.delete.yaml
@@ -1,0 +1,28 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: network.rbac.delete
+parameters:
+    base:
+        default: network rbac delete
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('network_rbac_delete = openstackclient.network.v2.network_rbac:DeleteNetworkRBAC')
+        immutable: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    rbac_policy:
+        description: RBAC policy(s) to delete (ID only)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/network.rbac.list.yaml
+++ b/actions/network.rbac.list.yaml
@@ -1,0 +1,33 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: network.rbac.list
+parameters:
+    base:
+        default: network rbac list
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('network_rbac_list = openstackclient.network.v2.network_rbac:ListNetworkRBAC')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+runner_type: run-python

--- a/actions/network.rbac.set.yaml
+++ b/actions/network.rbac.set.yaml
@@ -1,0 +1,36 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: network.rbac.set
+parameters:
+    base:
+        default: network rbac set
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('network_rbac_set = openstackclient.network.v2.network_rbac:SetNetworkRBAC')
+        immutable: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    rbac_policy:
+        description: RBAC policy to be modified (ID only)
+        required: true
+        type: string
+    target_project:
+        description: The project to which the RBAC policy will be enforced (name or
+            ID)
+        type: string
+    target_project_domain:
+        description: Domain the target project belongs to (name or ID). This can be
+            used in case collisions between project names exist.
+        type: string
+runner_type: run-python

--- a/actions/network.rbac.show.yaml
+++ b/actions/network.rbac.show.yaml
@@ -1,0 +1,37 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: network.rbac.show
+parameters:
+    base:
+        default: network rbac show
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('network_rbac_show = openstackclient.network.v2.network_rbac:ShowNetworkRBAC')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: json, shell,
+            table, value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    rbac_policy:
+        description: RBAC policy (ID only)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/network.segment.create.yaml
+++ b/actions/network.segment.create.yaml
@@ -1,0 +1,57 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: network.segment.create
+parameters:
+    base:
+        default: network segment create
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    description:
+        description: Network segment description
+        type: string
+    ep:
+        default: EntryPoint.parse('network_segment_create = openstackclient.network.v2.network_segment:CreateNetworkSegment')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: json, shell,
+            table, value, yaml)'
+        type: string
+    name:
+        description: New network segment name
+        required: true
+        type: string
+    network:
+        description: Network this network segment belongs to (name or ID)
+        required: true
+        type: string
+    network_type:
+        description: 'Network type of this network segment (flat, geneve, gre, local,
+            vlan or vxlan) (choices: flat, geneve, gre, local, vlan, vxlan)'
+        required: true
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    physical_network:
+        description: Physical network name of this network segment
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    segment:
+        description: Segment identifier for this network segment which is based on
+            the network type, VLAN ID for vlan network type and tunnel ID for geneve,
+            gre and vxlan network types
+        type: integer
+runner_type: run-python

--- a/actions/network.segment.delete.yaml
+++ b/actions/network.segment.delete.yaml
@@ -1,0 +1,28 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: network.segment.delete
+parameters:
+    base:
+        default: network segment delete
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('network_segment_delete = openstackclient.network.v2.network_segment:DeleteNetworkSegment')
+        immutable: true
+        type: string
+    network_segment:
+        description: Network segment(s) to delete (name or ID)
+        required: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+runner_type: run-python

--- a/actions/network.segment.list.yaml
+++ b/actions/network.segment.list.yaml
@@ -1,0 +1,40 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: network.segment.list
+parameters:
+    base:
+        default: network segment list
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('network_segment_list = openstackclient.network.v2.network_segment:ListNetworkSegment')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
+        type: string
+    long:
+        default: false
+        description: List additional fields in output
+        type: boolean
+    network:
+        description: List network segments that belong to this network (name or ID)
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+runner_type: run-python

--- a/actions/network.segment.set.yaml
+++ b/actions/network.segment.set.yaml
@@ -1,0 +1,34 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: network.segment.set
+parameters:
+    base:
+        default: network segment set
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    description:
+        description: Set network segment description
+        type: string
+    ep:
+        default: EntryPoint.parse('network_segment_set = openstackclient.network.v2.network_segment:SetNetworkSegment')
+        immutable: true
+        type: string
+    name:
+        description: Set network segment name
+        type: string
+    network_segment:
+        description: Network segment to modify (name or ID)
+        required: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+runner_type: run-python

--- a/actions/network.segment.show.yaml
+++ b/actions/network.segment.show.yaml
@@ -1,0 +1,37 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: network.segment.show
+parameters:
+    base:
+        default: network segment show
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('network_segment_show = openstackclient.network.v2.network_segment:ShowNetworkSegment')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: json, shell,
+            table, value, yaml)'
+        type: string
+    network_segment:
+        description: Network segment to display (name or ID)
+        required: true
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+runner_type: run-python

--- a/actions/network.service.provider.list.yaml
+++ b/actions/network.service.provider.list.yaml
@@ -1,0 +1,33 @@
+---
+description: List Service Providers
+enabled: true
+entry_point: src/wrapper.py
+name: network.service.provider.list
+parameters:
+    base:
+        default: network service provider list
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('network_service_provider_list = openstackclient.network.v2.network_service_provider:ListNetworkServiceProvider')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+runner_type: run-python

--- a/actions/network.set.yaml
+++ b/actions/network.set.yaml
@@ -1,5 +1,5 @@
 ---
-description: Set network properties
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: network.set
@@ -8,31 +8,95 @@ parameters:
         default: network set
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    default:
+        default: false
+        description: Set the network as the default external network
+        type: boolean
+    description:
+        description: Set network description
+        type: string
     disable:
-        default: true
+        default: false
         description: Disable network
+        type: boolean
+    disable_port_security:
+        default: false
+        description: Disable port security by default for ports created on this network
         type: boolean
     enable:
         default: false
         description: Enable network
         type: boolean
+    enable_port_security:
+        default: false
+        description: Enable port security by default for ports created on this network
+        type: boolean
     ep:
         default: EntryPoint.parse('network_set = openstackclient.network.v2.network:SetNetwork')
         immutable: true
         type: string
-    identifier:
-        description: Network to modify (name or ID)
-        required: true
-        type: string
+    external:
+        default: false
+        description: Set this network as an external network (external-net extension
+            required)
+        type: boolean
+    internal:
+        default: false
+        description: Set this network as an internal network
+        type: boolean
     name:
         description: Set network name
         type: string
+    network:
+        description: Network to modify (name or ID)
+        required: true
+        type: string
+    no_default:
+        default: false
+        description: Do not use the network as the default external network
+        type: boolean
+    no_qos_policy:
+        default: false
+        description: Remove the QoS policy attached to this network
+        type: boolean
     no_share:
-        default: true
+        default: false
         description: Do not share the network between projects
         type: boolean
+    no_transparent_vlan:
+        default: false
+        description: Do not make the network VLAN transparent
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    provider_network_type:
+        description: 'The physical mechanism by which the virtual network is implemented.
+            The supported options are: flat, geneve, gre, local, vlan, vxlan. (choices:
+            flat, geneve, gre, local, vlan, vxlan)'
+        type: string
+    provider_physical_network:
+        description: Name of the physical network over which the virtual network is
+            implemented
+        type: string
+    provider_segment:
+        description: VLAN ID for VLAN networks or Tunnel ID for GENEVE/GRE/VXLAN networks
+        type: string
+    qos_policy:
+        description: QoS policy to attach to this network (name or ID)
+        type: string
     share:
         default: false
         description: Share the network between projects
+        type: boolean
+    transparent_vlan:
+        default: false
+        description: Make the network VLAN transparent
         type: boolean
 runner_type: run-python

--- a/actions/object.create.yaml
+++ b/actions/object.create.yaml
@@ -1,5 +1,5 @@
 ---
-description: Upload object to container
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: object.create
@@ -7,6 +7,9 @@ parameters:
     base:
         default: object create
         immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
         type: string
     container:
         description: Container for new object
@@ -18,11 +21,25 @@ parameters:
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: csv, html, json,
-            table, yaml)'
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
         type: string
+    name:
+        description: Upload a file and rename it. Can only be used when uploading
+            a single object
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
     objects:
         description: Local filename(s) to upload
         required: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
 runner_type: run-python

--- a/actions/object.delete.yaml
+++ b/actions/object.delete.yaml
@@ -1,5 +1,5 @@
 ---
-description: Delete object from container
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: object.delete
@@ -7,6 +7,9 @@ parameters:
     base:
         default: object delete
         immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
         type: string
     container:
         description: Delete object(s) from <container>
@@ -19,5 +22,11 @@ parameters:
     objects:
         description: Object(s) to delete
         required: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
 runner_type: run-python

--- a/actions/object.list.yaml
+++ b/actions/object.list.yaml
@@ -1,5 +1,5 @@
 ---
-description: List objects
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: object.list
@@ -11,6 +11,9 @@ parameters:
     base:
         default: object list
         immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
         type: string
     container:
         description: Container to list
@@ -28,8 +31,8 @@ parameters:
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: csv, html, json,
-            table, yaml)'
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
         type: string
     limit:
         description: Limit the number of objects returned
@@ -41,7 +44,17 @@ parameters:
     marker:
         description: Anchor for paging
         type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
     prefix:
         description: Filter list using <prefix>
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
 runner_type: run-python

--- a/actions/object.save.yaml
+++ b/actions/object.save.yaml
@@ -1,5 +1,5 @@
 ---
-description: Save object locally
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: object.save
@@ -7,6 +7,9 @@ parameters:
     base:
         default: object save
         immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
         type: string
     container:
         description: Download <object> from <container>
@@ -22,5 +25,11 @@ parameters:
     object:
         description: Object to save
         required: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
 runner_type: run-python

--- a/actions/object.set.yaml
+++ b/actions/object.set.yaml
@@ -1,0 +1,37 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: object.set
+parameters:
+    base:
+        default: object set
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    container:
+        description: Modify <object> from <container>
+        required: true
+        type: string
+    ep:
+        default: EntryPoint.parse('object_set = openstackclient.object.v1.object:SetObject')
+        immutable: true
+        type: string
+    object:
+        description: Object to modify
+        required: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    property:
+        description: Set a property on this object (repeat option to set multiple
+            properties)
+        required: true
+        type: array
+runner_type: run-python

--- a/actions/object.show.yaml
+++ b/actions/object.show.yaml
@@ -1,5 +1,5 @@
 ---
-description: Display object details
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: object.show
@@ -7,6 +7,9 @@ parameters:
     base:
         default: object show
         immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
         type: string
     container:
         description: Display <object> from <container>
@@ -18,11 +21,21 @@ parameters:
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
         type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
     object:
         description: Object to display
         required: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
 runner_type: run-python

--- a/actions/object.store.account.set.yaml
+++ b/actions/object.store.account.set.yaml
@@ -1,0 +1,29 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: object.store.account.set
+parameters:
+    base:
+        default: object store account set
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('object_store_account_set = openstackclient.object.v1.account:SetAccount')
+        immutable: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    property:
+        description: Set a property on this account (repeat option to set multiple
+            properties)
+        required: true
+        type: array
+runner_type: run-python

--- a/actions/object.store.account.show.yaml
+++ b/actions/object.store.account.show.yaml
@@ -1,0 +1,33 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: object.store.account.show
+parameters:
+    base:
+        default: object store account show
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('object_store_account_show = openstackclient.object.v1.account:ShowAccount')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: json, shell,
+            table, value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+runner_type: run-python

--- a/actions/object.store.account.unset.yaml
+++ b/actions/object.store.account.unset.yaml
@@ -1,0 +1,30 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: object.store.account.unset
+parameters:
+    base:
+        default: object store account unset
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('object_store_account_unset = openstackclient.object.v1.account:UnsetAccount')
+        immutable: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    property:
+        default: []
+        description: Property to remove from account (repeat option to remove multiple
+            properties)
+        required: true
+        type: array
+runner_type: run-python

--- a/actions/object.unset.yaml
+++ b/actions/object.unset.yaml
@@ -1,0 +1,38 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: object.unset
+parameters:
+    base:
+        default: object unset
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    container:
+        description: Modify <object> from <container>
+        required: true
+        type: string
+    ep:
+        default: EntryPoint.parse('object_unset = openstackclient.object.v1.object:UnsetObject')
+        immutable: true
+        type: string
+    object:
+        description: Object to modify
+        required: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    property:
+        default: []
+        description: Property to remove from object (repeat option to remove multiple
+            properties)
+        required: true
+        type: array
+runner_type: run-python

--- a/actions/port.create.yaml
+++ b/actions/port.create.yaml
@@ -1,0 +1,111 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: port.create
+parameters:
+    base:
+        default: port create
+        immutable: true
+        type: string
+    binding_profile:
+        description: Custom data to be passed as binding:profile. Data may be passed
+            as <key>=<value> or JSON. (repeat option to set multiple binding:profile
+            data)
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    description:
+        description: Description of this port
+        type: string
+    device:
+        description: Port device ID
+        type: string
+    device_id:
+        description: ==SUPPRESS==
+        type: string
+    device_owner:
+        description: Device owner of this port. This is the entity that uses the port
+            (for example, network:dhcp).
+        type: string
+    disable:
+        default: false
+        description: Disable port
+        type: boolean
+    disable_port_security:
+        default: false
+        description: Disable port security for this port
+        type: boolean
+    dns_name:
+        description: Set DNS name to this port (requires DNS integration extension)
+        type: string
+    enable:
+        default: true
+        description: Enable port (default)
+        type: boolean
+    enable_port_security:
+        default: false
+        description: Enable port security for this port (Default)
+        type: boolean
+    ep:
+        default: EntryPoint.parse('port_create = openstackclient.network.v2.port:CreatePort')
+        immutable: true
+        type: string
+    fixed_ip:
+        description: 'Desired IP and/or subnet (name or ID) for this port: subnet=<subnet>,ip-address=<ip-address>
+            (repeat option to set multiple fixed IP addresses)'
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: json, shell,
+            table, value, yaml)'
+        type: string
+    host:
+        description: Allocate port on host <host-id> (ID only)
+        type: string
+    host_id:
+        description: ==SUPPRESS==
+        type: string
+    mac_address:
+        description: MAC address of this port
+        type: string
+    name:
+        description: Name of this port
+        required: true
+        type: string
+    network:
+        description: Network this port belongs to (name or ID)
+        required: true
+        type: string
+    no_security_group:
+        default: false
+        description: Associate no security groups with this port
+        type: boolean
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project:
+        description: Owner's project (name or ID)
+        type: string
+    project_domain:
+        description: Domain the project belongs to (name or ID). This can be used
+            in case collisions between project names exist.
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    security_group:
+        description: Security group to associate with this port (name or ID) (repeat
+            option to set multiple security groups)
+        type: array
+    vnic_type:
+        description: 'VNIC type for this port (direct | direct-physical | macvtap
+            | normal | baremetal, default: normal) (choices: direct, direct-physical,
+            macvtap, normal, baremetal)'
+        type: string
+runner_type: run-python

--- a/actions/port.delete.yaml
+++ b/actions/port.delete.yaml
@@ -1,0 +1,28 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: port.delete
+parameters:
+    base:
+        default: port delete
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('port_delete = openstackclient.network.v2.port:DeletePort')
+        immutable: true
+        type: string
+    port:
+        description: Port(s) to delete (name or ID)
+        required: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+runner_type: run-python

--- a/actions/port.list.yaml
+++ b/actions/port.list.yaml
@@ -1,0 +1,53 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: port.list
+parameters:
+    base:
+        default: port list
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    device_owner:
+        description: List only ports with the specified device owner. This is the
+            entity that uses the port (for example, network:dhcp).
+        type: string
+    ep:
+        default: EntryPoint.parse('port_list = openstackclient.network.v2.port:ListPort')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
+        type: string
+    long:
+        default: false
+        description: List additional fields in output
+        type: boolean
+    mac_address:
+        description: List only ports with this MAC address
+        type: string
+    network:
+        description: List only ports connected to this network (name or ID)
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    router:
+        description: List only ports attached to this router (name or ID)
+        type: string
+    server:
+        description: List only ports attached to this server (name or ID)
+        type: string
+runner_type: run-python

--- a/actions/port.set.yaml
+++ b/actions/port.set.yaml
@@ -1,0 +1,101 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: port.set
+parameters:
+    base:
+        default: port set
+        immutable: true
+        type: string
+    binding_profile:
+        description: Custom data to be passed as binding:profile. Data may be passed
+            as <key>=<value> or JSON. (repeat option to set multiple binding:profile
+            data)
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    description:
+        description: Description of this port
+        type: string
+    device:
+        description: Port device ID
+        type: string
+    device_id:
+        description: ==SUPPRESS==
+        type: string
+    device_owner:
+        description: Device owner of this port. This is the entity that uses the port
+            (for example, network:dhcp).
+        type: string
+    disable:
+        default: false
+        description: Disable port
+        type: boolean
+    disable_port_security:
+        default: false
+        description: Disable port security for this port
+        type: boolean
+    dns_name:
+        description: Set DNS name to this port (requires DNS integration extension)
+        type: string
+    enable:
+        default: false
+        description: Enable port
+        type: boolean
+    enable_port_security:
+        default: false
+        description: Enable port security for this port
+        type: boolean
+    ep:
+        default: EntryPoint.parse('port_set = openstackclient.network.v2.port:SetPort')
+        immutable: true
+        type: string
+    fixed_ip:
+        description: 'Desired IP and/or subnet (name or ID) for this port: subnet=<subnet>,ip-address=<ip-address>
+            (repeat option to set multiple fixed IP addresses)'
+        type: string
+    host:
+        description: Allocate port on host <host-id> (ID only)
+        type: string
+    host_id:
+        description: ==SUPPRESS==
+        type: string
+    name:
+        description: Set port name
+        type: string
+    no_binding_profile:
+        default: false
+        description: Clear existing information of binding:profile.Specify both --binding-profile
+            and --no-binding-profile to overwrite the current binding:profile information.
+        type: boolean
+    no_fixed_ip:
+        default: false
+        description: Clear existing information of fixed IP addresses.Specify both
+            --fixed-ip and --no-fixed-ip to overwrite the current fixed IP addresses.
+        type: boolean
+    no_security_group:
+        default: false
+        description: Clear existing security groups associated with this port
+        type: boolean
+    port:
+        description: Port to modify (name or ID)
+        required: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    security_group:
+        description: Security group to associate with this port (name or ID) (repeat
+            option to set multiple security groups)
+        type: array
+    vnic_type:
+        description: 'VNIC type for this port (direct | direct-physical | macvtap
+            | normal | baremetal, default: normal) (choices: direct, direct-physical,
+            macvtap, normal, baremetal)'
+        type: string
+runner_type: run-python

--- a/actions/port.show.yaml
+++ b/actions/port.show.yaml
@@ -1,0 +1,37 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: port.show
+parameters:
+    base:
+        default: port show
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('port_show = openstackclient.network.v2.port:ShowPort')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: json, shell,
+            table, value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    port:
+        description: Port to display (name or ID)
+        required: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+runner_type: run-python

--- a/actions/port.unset.yaml
+++ b/actions/port.unset.yaml
@@ -1,0 +1,41 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: port.unset
+parameters:
+    base:
+        default: port unset
+        immutable: true
+        type: string
+    binding_profile:
+        description: Desired key which should be removed from binding:profile(repeat
+            option to unset multiple binding:profile data)
+        type: array
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('port_unset = openstackclient.network.v2.port:UnsetPort')
+        immutable: true
+        type: string
+    fixed_ip:
+        description: 'Desired IP and/or subnet (name or ID) which should be removed
+            from this port: subnet=<subnet>,ip-address=<ip-address> (repeat option
+            to unset multiple fixed IP addresses)'
+        type: string
+    port:
+        description: Port to modify (name or ID)
+        required: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    security_group:
+        description: Security group which should be removed this port (name or ID)
+            (repeat option to unset multiple security groups)
+        type: array
+runner_type: run-python

--- a/actions/project.create.yaml
+++ b/actions/project.create.yaml
@@ -1,5 +1,5 @@
 ---
-description: Create new project
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: project.create
@@ -7,6 +7,9 @@ parameters:
     base:
         default: project create
         immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
         type: string
     description:
         description: Project description
@@ -25,17 +28,27 @@ parameters:
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
         type: string
     name:
         description: New project name
         required: true
         type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
     or_show:
         default: false
         description: Return existing project
         type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
     property:
         description: Add a property to <name> (repeat option to set multiple properties)
         type: array

--- a/actions/project.delete.yaml
+++ b/actions/project.delete.yaml
@@ -1,5 +1,5 @@
 ---
-description: Delete project(s)
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: project.delete
@@ -8,9 +8,18 @@ parameters:
         default: project delete
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('project_delete = openstackclient.identity.v2_0.project:DeleteProject')
         immutable: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     projects:
         description: Project(s) to delete (name or ID)

--- a/actions/project.list.yaml
+++ b/actions/project.list.yaml
@@ -1,5 +1,5 @@
 ---
-description: List projects
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: project.list
@@ -8,17 +8,30 @@ parameters:
         default: project list
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('project_list = openstackclient.identity.v2_0.project:ListProject')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: csv, html, json,
-            table, yaml)'
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
         type: string
     long:
         default: false
         description: List additional fields in output
         type: boolean
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
 runner_type: run-python

--- a/actions/project.set.yaml
+++ b/actions/project.set.yaml
@@ -1,5 +1,5 @@
 ---
-description: Set project properties
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: project.set
@@ -7,6 +7,9 @@ parameters:
     base:
         default: project set
         immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
         type: string
     description:
         description: Set project description
@@ -29,6 +32,12 @@ parameters:
     project:
         description: Project to modify (name or ID)
         required: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     property:
         description: Set a project property (repeat option to set multiple properties)

--- a/actions/project.show.yaml
+++ b/actions/project.show.yaml
@@ -1,5 +1,5 @@
 ---
-description: Display project details
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: project.show
@@ -8,17 +8,30 @@ parameters:
         default: project show
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('project_show = openstackclient.identity.v2_0.project:ShowProject')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
         type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
     project:
         description: Project to display (name or ID)
         required: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
 runner_type: run-python

--- a/actions/project.unset.yaml
+++ b/actions/project.unset.yaml
@@ -1,0 +1,32 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: project.unset
+parameters:
+    base:
+        default: project unset
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('project_unset = openstackclient.identity.v2_0.project:UnsetProject')
+        immutable: true
+        type: string
+    project:
+        description: Project to modify (name or ID)
+        required: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    property:
+        default: []
+        description: Unset a project property (repeat option to unset multiple properties)
+        type: array
+runner_type: run-python

--- a/actions/quota.show.yaml
+++ b/actions/quota.show.yaml
@@ -1,5 +1,5 @@
 ---
-description: Show quotas for project or class
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: quota.show
@@ -12,6 +12,9 @@ parameters:
         default: false
         description: Show quotas for <class>
         type: boolean
+    cloud:
+        description: A specific cloud to query
+        type: string
     default:
         default: false
         description: Show default quotas for <project>
@@ -22,11 +25,20 @@ parameters:
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
         type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
     project:
-        description: Show this project or class (name/ID)
-        required: true
+        description: Show quotas for this project or class (name or ID)
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
 runner_type: run-python

--- a/actions/role.add.yaml
+++ b/actions/role.add.yaml
@@ -1,5 +1,5 @@
 ---
-description: Add role to project:user
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: role.add
@@ -8,18 +8,31 @@ parameters:
         default: role add
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('role_add = openstackclient.identity.v2_0.role:AddRole')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
         type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
     project:
         description: Include <project> (name or ID)
         required: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     role:
         description: Role to add to <project>:<user> (name or ID)

--- a/actions/role.assignment.list.yaml
+++ b/actions/role.assignment.list.yaml
@@ -1,0 +1,52 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: role.assignment.list
+parameters:
+    auth_project:
+        default: false
+        description: Only list assignments for the project to which the authenticated
+            user's token is scoped
+        type: boolean
+    auth_user:
+        default: false
+        description: Only list assignments for the authenticated user
+        type: boolean
+    base:
+        default: role assignment list
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('role_assignment_list = openstackclient.identity.v2_0.role_assignment:ListRoleAssignment')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
+        type: string
+    names:
+        default: false
+        description: Display names instead of IDs
+        type: boolean
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project:
+        description: Project to filter (name or ID)
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    user:
+        description: User to filter (name or ID)
+        type: string
+runner_type: run-python

--- a/actions/role.create.yaml
+++ b/actions/role.create.yaml
@@ -1,5 +1,5 @@
 ---
-description: Create new role
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: role.create
@@ -8,19 +8,32 @@ parameters:
         default: role create
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('role_create = openstackclient.identity.v2_0.role:CreateRole')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
         type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
     or_show:
         default: false
         description: Return existing role
         type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
     role_name:
         description: New role name
         required: true

--- a/actions/role.delete.yaml
+++ b/actions/role.delete.yaml
@@ -1,5 +1,5 @@
 ---
-description: Delete role(s)
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: role.delete
@@ -8,9 +8,18 @@ parameters:
         default: role delete
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('role_delete = openstackclient.identity.v2_0.role:DeleteRole')
         immutable: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     roles:
         description: Role(s) to delete (name or ID)

--- a/actions/role.list.yaml
+++ b/actions/role.list.yaml
@@ -1,5 +1,5 @@
 ---
-description: List roles
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: role.list
@@ -8,17 +8,30 @@ parameters:
         default: role list
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('role_list = openstackclient.identity.v2_0.role:ListRole')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: csv, html, json,
-            table, yaml)'
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
         type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
     project:
         description: Filter roles by <project> (name or ID)
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     user:
         description: Filter roles by <user> (name or ID)

--- a/actions/role.remove.yaml
+++ b/actions/role.remove.yaml
@@ -1,5 +1,5 @@
 ---
-description: 'Remove role from project : user'
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: role.remove
@@ -8,6 +8,9 @@ parameters:
         default: role remove
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('role_remove = openstackclient.identity.v2_0.role:RemoveRole')
         immutable: true
@@ -15,6 +18,12 @@ parameters:
     project:
         description: Include <project> (name or ID)
         required: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     role:
         description: Role to remove (name or ID)

--- a/actions/role.show.yaml
+++ b/actions/role.show.yaml
@@ -1,5 +1,5 @@
 ---
-description: Display role details
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: role.show
@@ -8,14 +8,27 @@ parameters:
         default: role show
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('role_show = openstackclient.identity.v2_0.role:ShowRole')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     role:
         description: Role to display (name or ID)

--- a/actions/router.add.port.yaml
+++ b/actions/router.add.port.yaml
@@ -1,0 +1,32 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: router.add.port
+parameters:
+    base:
+        default: router add port
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('router_add_port = openstackclient.network.v2.router:AddPortToRouter')
+        immutable: true
+        type: string
+    port:
+        description: Port to be added (name or ID)
+        required: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    router:
+        description: Router to which port will be added (name or ID)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/router.add.subnet.yaml
+++ b/actions/router.add.subnet.yaml
@@ -1,0 +1,32 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: router.add.subnet
+parameters:
+    base:
+        default: router add subnet
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('router_add_subnet = openstackclient.network.v2.router:AddSubnetToRouter')
+        immutable: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    router:
+        description: Router to which subnet will be added (name or ID)
+        required: true
+        type: string
+    subnet:
+        description: Subnet to be added (name or ID)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/router.create.yaml
+++ b/actions/router.create.yaml
@@ -1,0 +1,67 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: router.create
+parameters:
+    availability_zone_hint:
+        description: Availability Zone in which to create this router (Router Availability
+            Zone extension required, repeat option to set multiple availability zones)
+        type: array
+    base:
+        default: router create
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    description:
+        description: Set router description
+        type: string
+    disable:
+        default: false
+        description: Disable router
+        type: boolean
+    distributed:
+        default: false
+        description: Create a distributed router
+        type: boolean
+    enable:
+        default: true
+        description: Enable router (default)
+        type: boolean
+    ep:
+        default: EntryPoint.parse('router_create = openstackclient.network.v2.router:CreateRouter')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: json, shell,
+            table, value, yaml)'
+        type: string
+    ha:
+        default: false
+        description: Create a highly available router
+        type: boolean
+    name:
+        description: New router name
+        required: true
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project:
+        description: Owner's project (name or ID)
+        type: string
+    project_domain:
+        description: Domain the project belongs to (name or ID). This can be used
+            in case collisions between project names exist.
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+runner_type: run-python

--- a/actions/router.delete.yaml
+++ b/actions/router.delete.yaml
@@ -1,0 +1,28 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: router.delete
+parameters:
+    base:
+        default: router delete
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('router_delete = openstackclient.network.v2.router:DeleteRouter')
+        immutable: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    router:
+        description: Router(s) to delete (name or ID)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/router.list.yaml
+++ b/actions/router.list.yaml
@@ -1,0 +1,55 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: router.list
+parameters:
+    base:
+        default: router list
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    disable:
+        default: false
+        description: List disabled routers
+        type: boolean
+    enable:
+        default: false
+        description: List enabled routers
+        type: boolean
+    ep:
+        default: EntryPoint.parse('router_list = openstackclient.network.v2.router:ListRouter')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
+        type: string
+    long:
+        default: false
+        description: List additional fields in output
+        type: boolean
+    name:
+        description: List routers according to their name
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project:
+        description: List routers according to their project (name or ID)
+        type: string
+    project_domain:
+        description: Domain the project belongs to (name or ID). This can be used
+            in case collisions between project names exist.
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+runner_type: run-python

--- a/actions/router.remove.port.yaml
+++ b/actions/router.remove.port.yaml
@@ -1,0 +1,32 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: router.remove.port
+parameters:
+    base:
+        default: router remove port
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('router_remove_port = openstackclient.network.v2.router:RemovePortFromRouter')
+        immutable: true
+        type: string
+    port:
+        description: Port to be removed and deleted (name or ID)
+        required: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    router:
+        description: Router from which port will be removed (name or ID)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/router.remove.subnet.yaml
+++ b/actions/router.remove.subnet.yaml
@@ -1,0 +1,32 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: router.remove.subnet
+parameters:
+    base:
+        default: router remove subnet
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('router_remove_subnet = openstackclient.network.v2.router:RemoveSubnetFromRouter')
+        immutable: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    router:
+        description: Router from which the subnet will be removed (name or ID)
+        required: true
+        type: string
+    subnet:
+        description: Subnet to be removed (name or ID)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/router.set.yaml
+++ b/actions/router.set.yaml
@@ -1,0 +1,87 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: router.set
+parameters:
+    base:
+        default: router set
+        immutable: true
+        type: string
+    centralized:
+        default: false
+        description: Set router to centralized mode (disabled router only)
+        type: boolean
+    clear_routes:
+        default: false
+        description: ==SUPPRESS==
+        type: boolean
+    cloud:
+        description: A specific cloud to query
+        type: string
+    description:
+        description: Set router description
+        type: string
+    disable:
+        default: false
+        description: Disable router
+        type: boolean
+    disable_snat:
+        default: false
+        description: Disable Source NAT on external gateway
+        type: boolean
+    distributed:
+        default: false
+        description: Set router to distributed mode (disabled router only)
+        type: boolean
+    enable:
+        default: false
+        description: Enable router
+        type: boolean
+    enable_snat:
+        default: false
+        description: Enable Source NAT on external gateway
+        type: boolean
+    ep:
+        default: EntryPoint.parse('router_set = openstackclient.network.v2.router:SetRouter')
+        immutable: true
+        type: string
+    external_gateway:
+        description: External Network used as router's gateway (name or ID)
+        type: string
+    fixed_ip:
+        description: 'Desired IP and/or subnet (name or ID)on external gateway: subnet=<subnet>,ip-address=<ip-address>
+            (repeat option to set multiple fixed IP addresses)'
+        type: string
+    ha:
+        default: false
+        description: Set the router as highly available (disabled router only)
+        type: boolean
+    name:
+        description: Set router name
+        type: string
+    no_ha:
+        default: false
+        description: Clear high availablability attribute of the router (disabled
+            router only)
+        type: boolean
+    no_route:
+        default: false
+        description: Clear routes associated with the router
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    route:
+        description: 'Routes associated with the router destination: destination subnet
+            (in CIDR notation) gateway: nexthop IP address (repeat option to set multiple
+            routes)'
+        type: string
+    router:
+        description: Router to modify (name or ID)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/router.show.yaml
+++ b/actions/router.show.yaml
@@ -1,0 +1,37 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: router.show
+parameters:
+    base:
+        default: router show
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('router_show = openstackclient.network.v2.router:ShowRouter')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: json, shell,
+            table, value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    router:
+        description: Router to display (name or ID)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/router.unset.yaml
+++ b/actions/router.unset.yaml
@@ -1,0 +1,37 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: router.unset
+parameters:
+    base:
+        default: router unset
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('router_unset = openstackclient.network.v2.router:UnsetRouter')
+        immutable: true
+        type: string
+    external_gateway:
+        default: false
+        description: Remove external gateway information from the router
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    route:
+        description: 'Routes to be removed from the router destination: destination
+            subnet (in CIDR notation) gateway: nexthop IP address (repeat option to
+            unset multiple routes)'
+        type: string
+    router:
+        description: Router to modify (name or ID)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/server.add.fixed.ip.yaml
+++ b/actions/server.add.fixed.ip.yaml
@@ -1,0 +1,32 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: server.add.fixed.ip
+parameters:
+    base:
+        default: server add fixed ip
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('server_add_fixed_ip = openstackclient.compute.v2.server:AddFixedIP')
+        immutable: true
+        type: string
+    network:
+        description: Network (name or ID) to allocate the fixed IP address from
+        required: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    server:
+        description: Server (name or ID) to receive the fixed IP address
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/server.add.floating.ip.yaml
+++ b/actions/server.add.floating.ip.yaml
@@ -1,0 +1,32 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: server.add.floating.ip
+parameters:
+    base:
+        default: server add floating ip
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('server_add_floating_ip = openstackclient.compute.v2.server:AddFloatingIP')
+        immutable: true
+        type: string
+    ip_address:
+        description: Floating IP address (IP address only) to assign to server
+        required: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    server:
+        description: Server (name or ID) to receive the floating IP address
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/server.add.security.group.yaml
+++ b/actions/server.add.security.group.yaml
@@ -1,5 +1,5 @@
 ---
-description: Add security group to server
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: server.add.security.group
@@ -8,6 +8,9 @@ parameters:
         default: server add security group
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('server_add_security_group = openstackclient.compute.v2.server:AddServerSecurityGroup')
         immutable: true
@@ -15,6 +18,12 @@ parameters:
     group:
         description: Security group to add (name or ID)
         required: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     server:
         description: Server (name or ID)

--- a/actions/server.add.volume.yaml
+++ b/actions/server.add.volume.yaml
@@ -1,5 +1,5 @@
 ---
-description: Add volume to server
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: server.add.volume
@@ -8,12 +8,21 @@ parameters:
         default: server add volume
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     device:
         description: Server internal device name for volume
         type: string
     ep:
         default: EntryPoint.parse('server_add_volume = openstackclient.compute.v2.server:AddServerVolume')
         immutable: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     server:
         description: Server (name or ID)

--- a/actions/server.backup.create.yaml
+++ b/actions/server.backup.create.yaml
@@ -1,0 +1,51 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: server.backup.create
+parameters:
+    base:
+        default: server backup create
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('server_backup_create = openstackclient.compute.v2.server_backup:CreateServerBackup')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: json, shell,
+            table, value, yaml)'
+        type: string
+    name:
+        description: 'Name of the backup image (default: server name)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    rotate:
+        description: 'Number of backups to keep (default: 1)'
+        type: integer
+    server:
+        description: Server to back up (name or ID)
+        required: true
+        type: string
+    type:
+        description: 'Used to populate the backup_type property of the backup image
+            (default: empty)'
+        type: string
+    wait:
+        default: false
+        description: Wait for backup image create to complete
+        type: boolean
+runner_type: run-python

--- a/actions/server.create.yaml
+++ b/actions/server.create.yaml
@@ -1,5 +1,5 @@
 ---
-description: Create a new server
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: server.create
@@ -16,6 +16,9 @@ parameters:
         description: Map block devices; map is <id>:<type>:<size(GB)>:<delete_on_terminate>
             (optional extension)
         type: array
+    cloud:
+        description: A specific cloud to query
+        type: string
     config_drive:
         default: 'False'
         description: Use specified volume as the config drive, or 'True' to use an
@@ -27,15 +30,16 @@ parameters:
         type: string
     file:
         default: []
-        description: File to inject into image before boot (repeat for multiple files)
+        description: File to inject into image before boot (repeat option to set multiple
+            files)
         type: array
     flavor:
-        description: Create server with this flavor
+        description: Create server with this flavor (name or ID)
         required: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
         type: string
     hint:
@@ -43,7 +47,7 @@ parameters:
         description: Hints for the scheduler (optional extension)
         type: array
     image:
-        description: Create server from this image
+        description: Create server from this image (name or ID)
         type: string
     key_name:
         description: Keypair to inject into this server (optional extension)
@@ -64,13 +68,24 @@ parameters:
             to port with this UUID, v4-fixed-ip: IPv4 fixed address for NIC (optional),
             v6-fixed-ip: IPv6 fixed address for NIC (optional).'
         type: array
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
     property:
-        description: Set a property on this server (repeat for multiple values)
+        description: Set a property on this server (repeat option to set multiple
+            values)
         type: array
     security_group:
         default: []
-        description: Security group to assign to this server (repeat for multiple
-            groups)
+        description: Security group to assign to this server (name or ID) (repeat
+            option to set multiple groups)
         type: array
     server_name:
         description: New server name
@@ -80,7 +95,7 @@ parameters:
         description: User data file to serve from the metadata server
         type: string
     volume:
-        description: Create server from this volume
+        description: Create server from this volume (name or ID)
         type: string
     wait:
         default: false

--- a/actions/server.delete.yaml
+++ b/actions/server.delete.yaml
@@ -1,5 +1,5 @@
 ---
-description: Delete server(s)
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: server.delete
@@ -8,12 +8,25 @@ parameters:
         default: server delete
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('server_delete = openstackclient.compute.v2.server:DeleteServer')
         immutable: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     server:
         description: Server(s) to delete (name or ID)
         required: true
         type: string
+    wait:
+        default: false
+        description: Wait for delete to complete
+        type: boolean
 runner_type: run-python

--- a/actions/server.dump.create.yaml
+++ b/actions/server.dump.create.yaml
@@ -1,0 +1,31 @@
+---
+description: "Create a dump file in server(s)\n\n    Trigger crash dump in server(s)\
+    \ with features like kdump in Linux.\n    It will create a dump file in the server(s)\
+    \ dumping the server(s)'\n    memory, and also crash the server(s). OSC sees the\
+    \ dump file\n    (server dump) as a kind of resource.\n    "
+enabled: true
+entry_point: src/wrapper.py
+name: server.dump.create
+parameters:
+    base:
+        default: server dump create
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('server_dump_create = openstackclient.compute.v2.server:CreateServerDump')
+        immutable: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    server:
+        description: Server(s) to create dump file (name or ID)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/server.group.create.yaml
+++ b/actions/server.group.create.yaml
@@ -1,0 +1,41 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: server.group.create
+parameters:
+    base:
+        default: server group create
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('server_group_create = openstackclient.compute.v2.server_group:CreateServerGroup')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: json, shell,
+            table, value, yaml)'
+        type: string
+    name:
+        description: New server group name
+        required: true
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    policy:
+        description: Add a policy to <name> (repeat option to add multiple policies)
+        required: true
+        type: array
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+runner_type: run-python

--- a/actions/server.group.delete.yaml
+++ b/actions/server.group.delete.yaml
@@ -1,0 +1,28 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: server.group.delete
+parameters:
+    base:
+        default: server group delete
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('server_group_delete = openstackclient.compute.v2.server_group:DeleteServerGroup')
+        immutable: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    server_group:
+        description: server group(s) to delete (name or ID)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/server.group.list.yaml
+++ b/actions/server.group.list.yaml
@@ -1,0 +1,41 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: server.group.list
+parameters:
+    all_projects:
+        default: false
+        description: Display information from all projects (admin only)
+        type: boolean
+    base:
+        default: server group list
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('server_group_list = openstackclient.compute.v2.server_group:ListServerGroup')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
+        type: string
+    long:
+        default: false
+        description: List additional fields in output
+        type: boolean
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+runner_type: run-python

--- a/actions/server.group.show.yaml
+++ b/actions/server.group.show.yaml
@@ -1,0 +1,37 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: server.group.show
+parameters:
+    base:
+        default: server group show
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('server_group_show = openstackclient.compute.v2.server_group:ShowServerGroup')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: json, shell,
+            table, value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    server_group:
+        description: server group to display (name or ID)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/server.image.create.yaml
+++ b/actions/server.image.create.yaml
@@ -1,5 +1,5 @@
 ---
-description: Create a new disk image from a running server
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: server.image.create
@@ -8,24 +8,37 @@ parameters:
         default: server image create
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
-        default: EntryPoint.parse('server_image_create = openstackclient.compute.v2.server:CreateServerImage')
+        default: EntryPoint.parse('server_image_create = openstackclient.compute.v2.server_image:CreateServerImage')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
         type: string
     name:
-        description: Name of new image (default is server name)
+        description: 'Name of new disk image (default: server name)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     server:
-        description: Server (name or ID)
+        description: Server to create image (name or ID)
         required: true
         type: string
     wait:
         default: false
-        description: Wait for image create to complete
+        description: Wait for operation to complete
         type: boolean
 runner_type: run-python

--- a/actions/server.list.yaml
+++ b/actions/server.list.yaml
@@ -1,5 +1,5 @@
 ---
-description: List servers
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: server.list
@@ -12,23 +12,26 @@ parameters:
         default: server list
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('server_list = openstackclient.compute.v2.server:ListServer')
         immutable: true
         type: string
     flavor:
-        description: Search by flavor
+        description: Search by flavor (name or ID)
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: csv, html, json,
-            table, yaml)'
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
         type: string
     host:
         description: Search by hostname
         type: string
     image:
-        description: Search by image
+        description: Search by image (name or ID)
         type: string
     instance_name:
         description: Regular expression to match instance name (admin only)
@@ -39,17 +42,50 @@ parameters:
     ip6:
         description: Regular expression to match IPv6 addresses
         type: string
+    limit:
+        description: Maximum number of servers to display. If limit equals -1, all
+            servers will be displayed. If limit is greater than 'osapi_max_limit'
+            option of Nova API, 'osapi_max_limit' will be used instead.
+        type: integer
     long:
         default: false
         description: List additional fields in output
         type: boolean
+    marker:
+        description: The last server (name or ID) of the previous page. Display list
+            of servers after marker. Display all servers if not specified.
+        type: string
     name:
         description: Regular expression to match names
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project:
+        description: Search by project (admin only) (name or ID)
+        type: string
+    project_domain:
+        description: Domain the project belongs to (name or ID). This can be used
+            in case collisions between project names exist.
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     reservation_id:
         description: Only return instances that match the reservation
         type: string
     status:
         description: Search by server status
+        type: string
+    user:
+        description: Search by user (admin only) (name or ID)
+        type: string
+    user_domain:
+        description: Domain the user belongs to (name or ID). This can be used in
+            case collisions between user names exist.
         type: string
 runner_type: run-python

--- a/actions/server.lock.yaml
+++ b/actions/server.lock.yaml
@@ -1,5 +1,5 @@
 ---
-description: Lock a server. A non-admin user will not be able to execute actions
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: server.lock
@@ -8,12 +8,21 @@ parameters:
         default: server lock
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('server_lock = openstackclient.compute.v2.server:LockServer')
         immutable: true
         type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
     server:
-        description: Server (name or ID)
+        description: Server(s) to lock (name or ID)
         required: true
         type: string
 runner_type: run-python

--- a/actions/server.migrate.yaml
+++ b/actions/server.migrate.yaml
@@ -1,5 +1,5 @@
 ---
-description: Migrate server to different host
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: server.migrate
@@ -9,9 +9,12 @@ parameters:
         immutable: true
         type: string
     block_migration:
-        default: true
+        default: false
         description: Perform a block live migration
         type: boolean
+    cloud:
+        description: A specific cloud to query
+        type: string
     disk_overcommit:
         default: false
         description: Allow disk over-commit on the destination host
@@ -27,12 +30,18 @@ parameters:
         default: false
         description: Do not over-commit disk on the destination host (default)
         type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
     server:
         description: Server (name or ID)
         required: true
         type: string
     shared_migration:
-        default: true
+        default: false
         description: Perform a shared live migration (default)
         type: boolean
     wait:

--- a/actions/server.pause.yaml
+++ b/actions/server.pause.yaml
@@ -1,5 +1,5 @@
 ---
-description: Pause server
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: server.pause
@@ -8,12 +8,21 @@ parameters:
         default: server pause
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('server_pause = openstackclient.compute.v2.server:PauseServer')
         immutable: true
         type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
     server:
-        description: Server (name or ID)
+        description: Server(s) to pause (name or ID)
         required: true
         type: string
 runner_type: run-python

--- a/actions/server.reboot.yaml
+++ b/actions/server.reboot.yaml
@@ -1,5 +1,5 @@
 ---
-description: Perform a hard or soft server reboot
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: server.reboot
@@ -8,6 +8,9 @@ parameters:
         default: server reboot
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('server_reboot = openstackclient.compute.v2.server:RebootServer')
         immutable: true
@@ -15,6 +18,12 @@ parameters:
     hard:
         default: SOFT
         description: Perform a hard reboot
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     server:
         description: Server (name or ID)

--- a/actions/server.rebuild.yaml
+++ b/actions/server.rebuild.yaml
@@ -1,5 +1,5 @@
 ---
-description: Rebuild server
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: server.rebuild
@@ -8,21 +8,34 @@ parameters:
         default: server rebuild
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('server_rebuild = openstackclient.compute.v2.server:RebuildServer')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
         type: string
     image:
-        description: Recreate server from this image
-        required: true
+        description: Recreate server from the specified image (name or ID). Defaults
+            to the currently used one.
         type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
     password:
         description: Set the password on the rebuilt instance
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     server:
         description: Server (name or ID)

--- a/actions/server.remove.fixed.ip.yaml
+++ b/actions/server.remove.fixed.ip.yaml
@@ -1,0 +1,32 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: server.remove.fixed.ip
+parameters:
+    base:
+        default: server remove fixed ip
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('server_remove_fixed_ip = openstackclient.compute.v2.server:RemoveFixedIP')
+        immutable: true
+        type: string
+    ip_address:
+        description: Fixed IP address (IP address only) to remove from the server
+        required: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    server:
+        description: Server (name or ID) to remove the fixed IP address from
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/server.remove.floating.ip.yaml
+++ b/actions/server.remove.floating.ip.yaml
@@ -1,0 +1,32 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: server.remove.floating.ip
+parameters:
+    base:
+        default: server remove floating ip
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('server_remove_floating_ip = openstackclient.compute.v2.server:RemoveFloatingIP')
+        immutable: true
+        type: string
+    ip_address:
+        description: Floating IP address (IP address only) to remove from server
+        required: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    server:
+        description: Server (name or ID) to remove the floating IP address from
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/server.remove.security.group.yaml
+++ b/actions/server.remove.security.group.yaml
@@ -1,5 +1,5 @@
 ---
-description: Remove security group from server
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: server.remove.security.group
@@ -8,6 +8,9 @@ parameters:
         default: server remove security group
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('server_remove_security_group = openstackclient.compute.v2.server:RemoveServerSecurityGroup')
         immutable: true
@@ -15,6 +18,12 @@ parameters:
     group:
         description: Name or ID of security group to remove from server
         required: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     server:
         description: Name or ID of server to use

--- a/actions/server.remove.volume.yaml
+++ b/actions/server.remove.volume.yaml
@@ -1,5 +1,5 @@
 ---
-description: Remove volume from server
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: server.remove.volume
@@ -8,9 +8,18 @@ parameters:
         default: server remove volume
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('server_remove_volume = openstackclient.compute.v2.server:RemoveServerVolume')
         immutable: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     server:
         description: Server (name or ID)

--- a/actions/server.rescue.yaml
+++ b/actions/server.rescue.yaml
@@ -1,5 +1,5 @@
 ---
-description: Put server in rescue mode
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: server.rescue
@@ -8,14 +8,27 @@ parameters:
         default: server rescue
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('server_rescue = openstackclient.compute.v2.server:RescueServer')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     server:
         description: Server (name or ID)

--- a/actions/server.resize.yaml
+++ b/actions/server.resize.yaml
@@ -1,5 +1,5 @@
 ---
-description: Scale server to a new flavor
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: server.resize
@@ -7,6 +7,9 @@ parameters:
     base:
         default: server resize
         immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
         type: string
     confirm:
         default: false
@@ -18,6 +21,12 @@ parameters:
         type: string
     flavor:
         description: Resize server to specified flavor
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     revert:
         default: false

--- a/actions/server.restore.yaml
+++ b/actions/server.restore.yaml
@@ -1,0 +1,28 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: server.restore
+parameters:
+    base:
+        default: server restore
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('server_restore = openstackclient.compute.v2.server:RestoreServer')
+        immutable: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    server:
+        description: Server(s) to restore (name or ID)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/server.resume.yaml
+++ b/actions/server.resume.yaml
@@ -1,5 +1,5 @@
 ---
-description: Resume server
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: server.resume
@@ -8,12 +8,21 @@ parameters:
         default: server resume
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('server_resume = openstackclient.compute.v2.server:ResumeServer')
         immutable: true
         type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
     server:
-        description: Server (name or ID)
+        description: Server(s) to resume (name or ID)
         required: true
         type: string
 runner_type: run-python

--- a/actions/server.set.yaml
+++ b/actions/server.set.yaml
@@ -1,5 +1,5 @@
 ---
-description: Set server properties
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: server.set
@@ -8,12 +8,21 @@ parameters:
         default: server set
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('server_set = openstackclient.compute.v2.server:SetServer')
         immutable: true
         type: string
     name:
         description: New server name
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     property:
         description: Property to add/change for this server (repeat option to set
@@ -26,5 +35,9 @@ parameters:
     server:
         description: Server (name or ID)
         required: true
+        type: string
+    state:
+        description: 'New server state (valid value: active, error) (choices: active,
+            error)'
         type: string
 runner_type: run-python

--- a/actions/server.shelve.yaml
+++ b/actions/server.shelve.yaml
@@ -1,0 +1,28 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: server.shelve
+parameters:
+    base:
+        default: server shelve
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('server_shelve = openstackclient.compute.v2.server:ShelveServer')
+        immutable: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    server:
+        description: Server(s) to shelve (name or ID)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/server.show.yaml
+++ b/actions/server.show.yaml
@@ -1,5 +1,5 @@
 ---
-description: Show server details
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: server.show
@@ -7,6 +7,9 @@ parameters:
     base:
         default: server show
         immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
         type: string
     diagnostics:
         default: false
@@ -18,8 +21,18 @@ parameters:
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     server:
         description: Server (name or ID)

--- a/actions/server.ssh.yaml
+++ b/actions/server.ssh.yaml
@@ -1,5 +1,5 @@
 ---
-description: Ssh to server
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: server.ssh
@@ -11,6 +11,9 @@ parameters:
     base:
         default: server ssh
         immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
         type: string
     ep:
         default: EntryPoint.parse('server_ssh = openstackclient.compute.v2.server:SshServer')
@@ -27,11 +30,8 @@ parameters:
         default: false
         description: Use only IPv6 addresses
         type: boolean
-    l:
-        description: ==SUPPRESS==
-        type: string
     login:
-        description: Login name (ssh -l option)
+        description: ==SUPPRESS==
         type: string
     option:
         description: ==SUPPRESS==
@@ -42,6 +42,12 @@ parameters:
     private:
         default: public
         description: Use private IP address
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     public:
         default: public

--- a/actions/server.start.yaml
+++ b/actions/server.start.yaml
@@ -1,0 +1,28 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: server.start
+parameters:
+    base:
+        default: server start
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('server_start = openstackclient.compute.v2.server:StartServer')
+        immutable: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    server:
+        description: Server(s) to start (name or ID)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/server.stop.yaml
+++ b/actions/server.stop.yaml
@@ -1,0 +1,28 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: server.stop
+parameters:
+    base:
+        default: server stop
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('server_stop = openstackclient.compute.v2.server:StopServer')
+        immutable: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    server:
+        description: Server(s) to stop (name or ID)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/server.suspend.yaml
+++ b/actions/server.suspend.yaml
@@ -1,5 +1,5 @@
 ---
-description: Suspend server
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: server.suspend
@@ -8,12 +8,21 @@ parameters:
         default: server suspend
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('server_suspend = openstackclient.compute.v2.server:SuspendServer')
         immutable: true
         type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
     server:
-        description: Server (name or ID)
+        description: Server(s) to suspend (name or ID)
         required: true
         type: string
 runner_type: run-python

--- a/actions/server.unlock.yaml
+++ b/actions/server.unlock.yaml
@@ -1,5 +1,5 @@
 ---
-description: Unlock server
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: server.unlock
@@ -8,12 +8,21 @@ parameters:
         default: server unlock
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('server_unlock = openstackclient.compute.v2.server:UnlockServer')
         immutable: true
         type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
     server:
-        description: Server (name or ID)
+        description: Server(s) to unlock (name or ID)
         required: true
         type: string
 runner_type: run-python

--- a/actions/server.unpause.yaml
+++ b/actions/server.unpause.yaml
@@ -1,5 +1,5 @@
 ---
-description: Unpause server
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: server.unpause
@@ -8,12 +8,21 @@ parameters:
         default: server unpause
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('server_unpause = openstackclient.compute.v2.server:UnpauseServer')
         immutable: true
         type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
     server:
-        description: Server (name or ID)
+        description: Server(s) to unpause (name or ID)
         required: true
         type: string
 runner_type: run-python

--- a/actions/server.unrescue.yaml
+++ b/actions/server.unrescue.yaml
@@ -1,5 +1,5 @@
 ---
-description: Restore server from rescue mode
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: server.unrescue
@@ -8,9 +8,18 @@ parameters:
         default: server unrescue
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('server_unrescue = openstackclient.compute.v2.server:UnrescueServer')
         immutable: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     server:
         description: Server (name or ID)

--- a/actions/server.unset.yaml
+++ b/actions/server.unset.yaml
@@ -1,5 +1,5 @@
 ---
-description: Unset server properties
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: server.unset
@@ -8,13 +8,22 @@ parameters:
         default: server unset
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('server_unset = openstackclient.compute.v2.server:UnsetServer')
         immutable: true
         type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
     property:
         default: []
-        description: Property key to remove from server (repeat to unset multiple
+        description: Property key to remove from server (repeat option to remove multiple
             values)
         type: array
     server:

--- a/actions/server.unshelve.yaml
+++ b/actions/server.unshelve.yaml
@@ -1,0 +1,28 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: server.unshelve
+parameters:
+    base:
+        default: server unshelve
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('server_unshelve = openstackclient.compute.v2.server:UnshelveServer')
+        immutable: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    server:
+        description: Server(s) to unshelve (name or ID)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/service.create.yaml
+++ b/actions/service.create.yaml
@@ -1,5 +1,5 @@
 ---
-description: Create new service
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: service.create
@@ -7,6 +7,9 @@ parameters:
     base:
         default: service create
         immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
         type: string
     description:
         description: New service description
@@ -17,11 +20,21 @@ parameters:
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
         type: string
     name:
         description: New service name
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     type:
         description: ==SUPPRESS==

--- a/actions/service.delete.yaml
+++ b/actions/service.delete.yaml
@@ -1,5 +1,5 @@
 ---
-description: Delete service
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: service.delete
@@ -8,12 +8,21 @@ parameters:
         default: service delete
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('service_delete = openstackclient.identity.v2_0.service:DeleteService')
         immutable: true
         type: string
-    service:
-        description: Service to delete (name or ID)
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    services:
+        description: Service(s) to delete (type, name or ID)
         required: true
         type: string
 runner_type: run-python

--- a/actions/service.list.yaml
+++ b/actions/service.list.yaml
@@ -1,5 +1,5 @@
 ---
-description: List services
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: service.list
@@ -8,17 +8,30 @@ parameters:
         default: service list
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('service_list = openstackclient.identity.v2_0.service:ListService')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: csv, html, json,
-            table, yaml)'
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
         type: string
     long:
         default: false
         description: List additional fields in output
         type: boolean
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
 runner_type: run-python

--- a/actions/service.show.yaml
+++ b/actions/service.show.yaml
@@ -1,5 +1,5 @@
 ---
-description: Display service details
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: service.show
@@ -12,14 +12,27 @@ parameters:
         default: false
         description: Show service catalog information
         type: boolean
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('service_show = openstackclient.identity.v2_0.service:ShowService')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     service:
         description: Service to display (type, name or ID)

--- a/actions/snapshot.create.yaml
+++ b/actions/snapshot.create.yaml
@@ -1,5 +1,5 @@
 ---
-description: Create new snapshot
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: snapshot.create
@@ -8,11 +8,14 @@ parameters:
         default: snapshot create
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     description:
         description: Description of the snapshot
         type: string
     ep:
-        default: EntryPoint.parse('snapshot_create = openstackclient.volume.v1.snapshot:CreateSnapshot')
+        default: EntryPoint.parse('snapshot_create = openstackclient.volume.v2.snapshot:CreateSnapshot')
         immutable: true
         type: string
     force:
@@ -21,13 +24,26 @@ parameters:
         type: boolean
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
         type: string
     name:
         description: Name of the snapshot
-        required: true
         type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    property:
+        description: Set a property to this snapshot (repeat option to set multiple
+            properties)
+        type: array
     volume:
         description: Volume to snapshot (name or ID)
         required: true

--- a/actions/snapshot.delete.yaml
+++ b/actions/snapshot.delete.yaml
@@ -1,5 +1,5 @@
 ---
-description: Delete snapshot(s)
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: snapshot.delete
@@ -8,9 +8,18 @@ parameters:
         default: snapshot delete
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
-        default: EntryPoint.parse('snapshot_delete = openstackclient.volume.v1.snapshot:DeleteSnapshot')
+        default: EntryPoint.parse('snapshot_delete = openstackclient.volume.v2.snapshot:DeleteSnapshot')
         immutable: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     snapshots:
         description: Snapshot(s) to delete (name or ID)

--- a/actions/snapshot.list.yaml
+++ b/actions/snapshot.list.yaml
@@ -1,24 +1,47 @@
 ---
-description: List snapshots
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: snapshot.list
 parameters:
+    all_projects:
+        default: false
+        description: Include all projects (admin only)
+        type: boolean
     base:
         default: snapshot list
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
-        default: EntryPoint.parse('snapshot_list = openstackclient.volume.v1.snapshot:ListSnapshot')
+        default: EntryPoint.parse('snapshot_list = openstackclient.volume.v2.snapshot:ListSnapshot')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: csv, html, json,
-            table, yaml)'
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
         type: string
+    limit:
+        description: Maximum number of snapshots to display
+        type: integer
     long:
         default: false
         description: List additional fields in output
         type: boolean
+    marker:
+        description: The last snapshot ID of the previous page
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
 runner_type: run-python

--- a/actions/snapshot.set.yaml
+++ b/actions/snapshot.set.yaml
@@ -1,5 +1,5 @@
 ---
-description: Set snapshot properties
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: snapshot.set
@@ -8,15 +8,24 @@ parameters:
         default: snapshot set
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     description:
         description: New snapshot description
         type: string
     ep:
-        default: EntryPoint.parse('snapshot_set = openstackclient.volume.v1.snapshot:SetSnapshot')
+        default: EntryPoint.parse('snapshot_set = openstackclient.volume.v2.snapshot:SetSnapshot')
         immutable: true
         type: string
     name:
         description: New snapshot name
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     property:
         description: Property to add/change for this snapshot (repeat option to set
@@ -25,5 +34,11 @@ parameters:
     snapshot:
         description: Snapshot to modify (name or ID)
         required: true
+        type: string
+    state:
+        description: 'New snapshot state. ("available", "error", "creating", "deleting",
+            or "error_deleting") (admin only) (This option simply changes the state
+            of the snapshot in the database with no regard to actual status, exercise
+            caution when using) (choices: available, error, creating, deleting, error-deleting)'
         type: string
 runner_type: run-python

--- a/actions/snapshot.show.yaml
+++ b/actions/snapshot.show.yaml
@@ -1,5 +1,5 @@
 ---
-description: Display snapshot details
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: snapshot.show
@@ -8,14 +8,27 @@ parameters:
         default: snapshot show
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
-        default: EntryPoint.parse('snapshot_show = openstackclient.volume.v1.snapshot:ShowSnapshot')
+        default: EntryPoint.parse('snapshot_show = openstackclient.volume.v2.snapshot:ShowSnapshot')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     snapshot:
         description: Snapshot to display (name or ID)

--- a/actions/snapshot.unset.yaml
+++ b/actions/snapshot.unset.yaml
@@ -1,5 +1,5 @@
 ---
-description: Unset snapshot properties
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: snapshot.unset
@@ -8,13 +8,23 @@ parameters:
         default: snapshot unset
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
-        default: EntryPoint.parse('snapshot_unset = openstackclient.volume.v1.snapshot:UnsetSnapshot')
+        default: EntryPoint.parse('snapshot_unset = openstackclient.volume.v2.snapshot:UnsetSnapshot')
         immutable: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     property:
         default: []
-        description: Property to remove from snapshot (repeat to remove multiple values)
+        description: Property to remove from snapshot (repeat option to remove multiple
+            properties)
         type: array
     snapshot:
         description: Snapshot to modify (name or ID)

--- a/actions/subnet.delete.yaml
+++ b/actions/subnet.delete.yaml
@@ -1,0 +1,28 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: subnet.delete
+parameters:
+    base:
+        default: subnet delete
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('subnet_delete = openstackclient.network.v2.subnet:DeleteSubnet')
+        immutable: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    subnet:
+        description: Subnet(s) to delete (name or ID)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/subnet.pool.create.yaml
+++ b/actions/subnet.pool.create.yaml
@@ -1,0 +1,81 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: subnet.pool.create
+parameters:
+    address_scope:
+        description: Set address scope associated with the subnet pool (name or ID),
+            prefixes must be unique across address scopes
+        type: string
+    base:
+        default: subnet pool create
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    default:
+        default: false
+        description: Set this as a default subnet pool
+        type: boolean
+    default_prefix_length:
+        description: Set subnet pool default prefix length
+        type: integer
+    description:
+        description: Set subnet pool description
+        type: string
+    ep:
+        default: EntryPoint.parse('subnet_pool_create = openstackclient.network.v2.subnet_pool:CreateSubnetPool')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: json, shell,
+            table, value, yaml)'
+        type: string
+    max_prefix_length:
+        description: Set subnet pool maximum prefix length
+        type: integer
+    min_prefix_length:
+        description: Set subnet pool minimum prefix length
+        type: integer
+    name:
+        description: Name of the new subnet pool
+        required: true
+        type: string
+    no_default:
+        default: false
+        description: Set this as a non-default subnet pool
+        type: boolean
+    no_share:
+        default: false
+        description: Set this subnet pool as not shared
+        type: boolean
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    pool_prefix:
+        description: Set subnet pool prefixes (in CIDR notation) (repeat option to
+            set multiple prefixes)
+        required: true
+        type: array
+    project:
+        description: Owner's project (name or ID)
+        type: string
+    project_domain:
+        description: Domain the project belongs to (name or ID). This can be used
+            in case collisions between project names exist.
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    share:
+        default: false
+        description: Set this subnet pool as shared
+        type: boolean
+runner_type: run-python

--- a/actions/subnet.pool.delete.yaml
+++ b/actions/subnet.pool.delete.yaml
@@ -1,0 +1,28 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: subnet.pool.delete
+parameters:
+    base:
+        default: subnet pool delete
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('subnet_pool_delete = openstackclient.network.v2.subnet_pool:DeleteSubnetPool')
+        immutable: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    subnet_pool:
+        description: Subnet pool(s) to delete (name or ID)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/subnet.pool.list.yaml
+++ b/actions/subnet.pool.list.yaml
@@ -1,0 +1,67 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: subnet.pool.list
+parameters:
+    address_scope:
+        description: List only subnet pools of given address scope (name or ID) in
+            output
+        type: string
+    base:
+        default: subnet pool list
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    default:
+        default: false
+        description: List subnet pools used as the default external subnet pool
+        type: boolean
+    ep:
+        default: EntryPoint.parse('subnet_pool_list = openstackclient.network.v2.subnet_pool:ListSubnetPool')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
+        type: string
+    long:
+        default: false
+        description: List additional fields in output
+        type: boolean
+    name:
+        description: List only subnet pools of given name in output
+        type: string
+    no_default:
+        default: false
+        description: List subnet pools not used as the default external subnet pool
+        type: boolean
+    no_share:
+        default: false
+        description: List subnet pools not shared between projects
+        type: boolean
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project:
+        description: List subnet pools according to their project (name or ID)
+        type: string
+    project_domain:
+        description: Domain the project belongs to (name or ID). This can be used
+            in case collisions between project names exist.
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    share:
+        default: false
+        description: List subnet pools shared between projects
+        type: boolean
+runner_type: run-python

--- a/actions/subnet.pool.set.yaml
+++ b/actions/subnet.pool.set.yaml
@@ -1,0 +1,63 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: subnet.pool.set
+parameters:
+    address_scope:
+        description: Set address scope associated with the subnet pool (name or ID),
+            prefixes must be unique across address scopes
+        type: string
+    base:
+        default: subnet pool set
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    default:
+        default: false
+        description: Set this as a default subnet pool
+        type: boolean
+    default_prefix_length:
+        description: Set subnet pool default prefix length
+        type: integer
+    description:
+        description: Set subnet pool description
+        type: string
+    ep:
+        default: EntryPoint.parse('subnet_pool_set = openstackclient.network.v2.subnet_pool:SetSubnetPool')
+        immutable: true
+        type: string
+    max_prefix_length:
+        description: Set subnet pool maximum prefix length
+        type: integer
+    min_prefix_length:
+        description: Set subnet pool minimum prefix length
+        type: integer
+    name:
+        description: Set subnet pool name
+        type: string
+    no_address_scope:
+        default: false
+        description: Remove address scope associated with the subnet pool
+        type: boolean
+    no_default:
+        default: false
+        description: Set this as a non-default subnet pool
+        type: boolean
+    pool_prefix:
+        description: Set subnet pool prefixes (in CIDR notation) (repeat option to
+            set multiple prefixes)
+        type: array
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    subnet_pool:
+        description: Subnet pool to modify (name or ID)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/subnet.pool.show.yaml
+++ b/actions/subnet.pool.show.yaml
@@ -1,0 +1,37 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: subnet.pool.show
+parameters:
+    base:
+        default: subnet pool show
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('subnet_pool_show = openstackclient.network.v2.subnet_pool:ShowSubnetPool')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: json, shell,
+            table, value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    subnet_pool:
+        description: Subnet pool to display (name or ID)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/subnet.pool.unset.yaml
+++ b/actions/subnet.pool.unset.yaml
@@ -1,0 +1,32 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: subnet.pool.unset
+parameters:
+    base:
+        default: subnet pool unset
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('subnet_pool_unset = openstackclient.network.v2.subnet_pool:UnsetSubnetPool')
+        immutable: true
+        type: string
+    pool_prefix:
+        description: Remove subnet pool prefixes (in CIDR notation). (repeat option
+            to unset multiple prefixes).
+        type: array
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    subnet_pool:
+        description: Subnet pool to modify (name or ID)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/subnet.set.yaml
+++ b/actions/subnet.set.yaml
@@ -1,0 +1,81 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: subnet.set
+parameters:
+    allocation_pool:
+        description: 'Allocation pool IP addresses for this subnet e.g.: start=192.168.199.2,end=192.168.199.254
+            (repeat option to add multiple IP addresses)'
+        type: string
+    base:
+        default: subnet set
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    description:
+        description: Set subnet description
+        type: string
+    dhcp:
+        default: false
+        description: Enable DHCP
+        type: boolean
+    dns_nameserver:
+        description: DNS server for this subnet (repeat option to set multiple DNS
+            servers)
+        type: array
+    ep:
+        default: EntryPoint.parse('subnet_set = openstackclient.network.v2.subnet:SetSubnet')
+        immutable: true
+        type: string
+    gateway:
+        description: 'Specify a gateway for the subnet. The options are: <ip-address>:
+            Specific IP address to use as the gateway, ''none'': This subnet will
+            not use a gateway, e.g.: --gateway 192.168.9.1, --gateway none.'
+        type: string
+    host_route:
+        description: 'Additional route for this subnet e.g.: destination=10.10.0.0/16,gateway=192.168.71.254
+            destination: destination subnet (in CIDR notation) gateway: nexthop IP
+            address (repeat option to add multiple routes)'
+        type: string
+    name:
+        description: Updated name of the subnet
+        type: string
+    no_allocation_pool:
+        default: false
+        description: Clear associated allocation-pools from the subnet. Specify both
+            --allocation-pool and --no-allocation-pool to overwrite the current allocation
+            pool information.
+        type: boolean
+    no_dhcp:
+        default: false
+        description: Disable DHCP
+        type: boolean
+    no_dns_nameservers:
+        default: false
+        description: Clear existing information of DNS Nameservers. Specify both --dns-nameserver
+            and --no-dns-nameserver to overwrite the current DNS Nameserver information.
+        type: boolean
+    no_host_route:
+        default: false
+        description: Clear associated host-routes from the subnet. Specify both --host-route
+            and --no-host-route to overwrite the current host route information.
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    service_type:
+        description: 'Service type for this subnet e.g.: network:floatingip_agent_gateway.
+            Must be a valid device owner value for a network port (repeat option to
+            set multiple service types)'
+        type: array
+    subnet:
+        description: Subnet to modify (name or ID)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/subnet.show.yaml
+++ b/actions/subnet.show.yaml
@@ -1,0 +1,37 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: subnet.show
+parameters:
+    base:
+        default: subnet show
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('subnet_show = openstackclient.network.v2.subnet:ShowSubnet')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: json, shell,
+            table, value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    subnet:
+        description: Subnet to display (name or ID)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/subnet.unset.yaml
+++ b/actions/subnet.unset.yaml
@@ -1,0 +1,47 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: subnet.unset
+parameters:
+    allocation_pool:
+        description: 'Allocation pool IP addresses to be removed from this subnet
+            e.g.: start=192.168.199.2,end=192.168.199.254 (repeat option to unset
+            multiple allocation pools)'
+        type: string
+    base:
+        default: subnet unset
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    dns_nameserver:
+        description: DNS server to be removed from this subnet (repeat option to unset
+            multiple DNS servers)
+        type: array
+    ep:
+        default: EntryPoint.parse('subnet_unset = openstackclient.network.v2.subnet:UnsetSubnet')
+        immutable: true
+        type: string
+    host_route:
+        description: 'Route to be removed from this subnet e.g.: destination=10.10.0.0/16,gateway=192.168.71.254
+            destination: destination subnet (in CIDR notation) gateway: nexthop IP
+            address (repeat option to unset multiple host routes)'
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    service_type:
+        description: 'Service type to be removed from this subnet e.g.: network:floatingip_agent_gateway.
+            Must be a valid device owner value for a network port (repeat option to
+            unset multiple service types)'
+        type: array
+    subnet:
+        description: Subnet to modify (name or ID)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/token.issue.yaml
+++ b/actions/token.issue.yaml
@@ -1,5 +1,5 @@
 ---
-description: Issue new token
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: token.issue
@@ -8,13 +8,26 @@ parameters:
         default: token issue
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('token_issue = openstackclient.identity.v2_0.token:IssueToken')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
 runner_type: run-python

--- a/actions/token.revoke.yaml
+++ b/actions/token.revoke.yaml
@@ -1,5 +1,5 @@
 ---
-description: Revoke existing token
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: token.revoke
@@ -8,9 +8,18 @@ parameters:
         default: token revoke
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('token_revoke = openstackclient.identity.v2_0.token:RevokeToken')
         immutable: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     token:
         description: Token to be deleted

--- a/actions/usage.list.yaml
+++ b/actions/usage.list.yaml
@@ -1,5 +1,5 @@
 ---
-description: List resource usage per project
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: usage.list
@@ -7,6 +7,9 @@ parameters:
     base:
         default: usage list
         immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
         type: string
     end:
         description: 'Usage range end date, ex 2012-01-20 (default: tomorrow)'
@@ -17,8 +20,18 @@ parameters:
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: csv, html, json,
-            table, yaml)'
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     start:
         description: 'Usage range start date, ex 2012-01-20 (default: 4 weeks ago)'

--- a/actions/usage.show.yaml
+++ b/actions/usage.show.yaml
@@ -1,5 +1,5 @@
 ---
-description: Show resource usage for a single project
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: usage.show
@@ -7,6 +7,9 @@ parameters:
     base:
         default: usage show
         immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
         type: string
     end:
         description: 'Usage range end date, ex 2012-01-20 (default: tomorrow)'
@@ -17,11 +20,21 @@ parameters:
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
         type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
     project:
         description: Name or ID of project to show usage for
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     start:
         description: 'Usage range start date, ex 2012-01-20 (default: 4 weeks ago)'

--- a/actions/user.create.yaml
+++ b/actions/user.create.yaml
@@ -1,5 +1,5 @@
 ---
-description: Create new user
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: user.create
@@ -7,6 +7,9 @@ parameters:
     base:
         default: user create
         immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
         type: string
     disable:
         default: false
@@ -25,13 +28,17 @@ parameters:
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
         type: string
     name:
         description: New user name
         required: true
         type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
     or_show:
         default: false
         description: Return existing user
@@ -45,5 +52,11 @@ parameters:
         type: boolean
     project:
         description: Default project (name or ID)
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
 runner_type: run-python

--- a/actions/user.delete.yaml
+++ b/actions/user.delete.yaml
@@ -1,5 +1,5 @@
 ---
-description: Delete user(s)
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: user.delete
@@ -8,9 +8,18 @@ parameters:
         default: user delete
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('user_delete = openstackclient.identity.v2_0.user:DeleteUser')
         immutable: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     users:
         description: User(s) to delete (name or ID)

--- a/actions/user.list.yaml
+++ b/actions/user.list.yaml
@@ -1,5 +1,5 @@
 ---
-description: List users
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: user.list
@@ -8,20 +8,33 @@ parameters:
         default: user list
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('user_list = openstackclient.identity.v2_0.user:ListUser')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: csv, html, json,
-            table, yaml)'
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
         type: string
     long:
         default: false
         description: List additional fields in output
         type: boolean
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
     project:
         description: Filter users by project (name or ID)
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
 runner_type: run-python

--- a/actions/user.role.list.yaml
+++ b/actions/user.role.list.yaml
@@ -1,5 +1,5 @@
 ---
-description: List user-role assignments
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: user.role.list
@@ -8,17 +8,30 @@ parameters:
         default: user role list
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('user_role_list = openstackclient.identity.v2_0.role:ListUserRole')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: csv, html, json,
-            table, yaml)'
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
         type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
     project:
         description: Filter users by <project> (name or ID)
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     user:
         description: User to list (name or ID)

--- a/actions/user.set.yaml
+++ b/actions/user.set.yaml
@@ -1,5 +1,5 @@
 ---
-description: Set user properties
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: user.set
@@ -7,6 +7,9 @@ parameters:
     base:
         default: user set
         immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
         type: string
     disable:
         default: false
@@ -36,8 +39,14 @@ parameters:
     project:
         description: Set default project (name or ID)
         type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
     user:
-        description: User to change (name or ID)
+        description: User to modify (name or ID)
         required: true
         type: string
 runner_type: run-python

--- a/actions/user.show.yaml
+++ b/actions/user.show.yaml
@@ -1,5 +1,5 @@
 ---
-description: Display user details
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: user.show
@@ -8,14 +8,27 @@ parameters:
         default: user show
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
         default: EntryPoint.parse('user_show = openstackclient.identity.v2_0.user:ShowUser')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     user:
         description: User to display (name or ID)

--- a/actions/volume.backup.create.yaml
+++ b/actions/volume.backup.create.yaml
@@ -1,0 +1,57 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: volume.backup.create
+parameters:
+    base:
+        default: volume backup create
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    container:
+        description: Optional backup container name
+        type: string
+    description:
+        description: Description of the backup
+        type: string
+    ep:
+        default: EntryPoint.parse('volume_backup_create = openstackclient.volume.v2.backup:CreateVolumeBackup')
+        immutable: true
+        type: string
+    force:
+        default: false
+        description: Allow to back up an in-use volume
+        type: boolean
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: json, shell,
+            table, value, yaml)'
+        type: string
+    incremental:
+        default: false
+        description: Perform an incremental backup
+        type: boolean
+    name:
+        description: Name of the backup
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    snapshot:
+        description: Snapshot to backup (name or ID)
+        type: string
+    volume:
+        description: Volume to backup (name or ID)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/volume.backup.delete.yaml
+++ b/actions/volume.backup.delete.yaml
@@ -1,0 +1,32 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: volume.backup.delete
+parameters:
+    backups:
+        description: Backup(s) to delete (name or ID)
+        required: true
+        type: string
+    base:
+        default: volume backup delete
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('volume_backup_delete = openstackclient.volume.v2.backup:DeleteVolumeBackup')
+        immutable: true
+        type: string
+    force:
+        default: false
+        description: Allow delete in state other than error or available
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+runner_type: run-python

--- a/actions/volume.backup.list.yaml
+++ b/actions/volume.backup.list.yaml
@@ -1,0 +1,58 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: volume.backup.list
+parameters:
+    all_projects:
+        default: false
+        description: Include all projects (admin only)
+        type: boolean
+    base:
+        default: volume backup list
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('volume_backup_list = openstackclient.volume.v2.backup:ListVolumeBackup')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
+        type: string
+    limit:
+        description: Maximum number of backups to display
+        type: integer
+    long:
+        default: false
+        description: List additional fields in output
+        type: boolean
+    marker:
+        description: The last backup of the previous page (name or ID)
+        type: string
+    name:
+        description: Filters results by the backup name
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    status:
+        description: 'Filters results by the backup status (''creating'', ''available'',
+            ''deleting'', ''error'', ''restoring'' or ''error_restoring'') (choices:
+            creating, available, deleting, error, restoring, error_restoring)'
+        type: string
+    volume:
+        description: Filters results by the volume which they backup (name or ID)
+        type: string
+runner_type: run-python

--- a/actions/volume.backup.restore.yaml
+++ b/actions/volume.backup.restore.yaml
@@ -1,0 +1,41 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: volume.backup.restore
+parameters:
+    backup:
+        description: Backup to restore (name or ID)
+        required: true
+        type: string
+    base:
+        default: volume backup restore
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('volume_backup_restore = openstackclient.volume.v2.backup:RestoreVolumeBackup')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: json, shell,
+            table, value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    volume:
+        description: Volume to restore to (name or ID)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/volume.backup.set.yaml
+++ b/actions/volume.backup.set.yaml
@@ -1,0 +1,40 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: volume.backup.set
+parameters:
+    backup:
+        description: Backup to modify (name or ID)
+        required: true
+        type: string
+    base:
+        default: volume backup set
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    description:
+        description: New backup description
+        type: string
+    ep:
+        default: EntryPoint.parse('volume_backup_set = openstackclient.volume.v2.backup:SetVolumeBackup')
+        immutable: true
+        type: string
+    name:
+        description: New backup name
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    state:
+        description: 'New backup state ("available" or "error") (admin only) (This
+            option simply changes the state of the backup in the database with no
+            regard to actual status, exercise caution when using) (choices: available,
+            error)'
+        type: string
+runner_type: run-python

--- a/actions/volume.backup.show.yaml
+++ b/actions/volume.backup.show.yaml
@@ -1,0 +1,37 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: volume.backup.show
+parameters:
+    backup:
+        description: Backup to display (name or ID)
+        required: true
+        type: string
+    base:
+        default: volume backup show
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('volume_backup_show = openstackclient.volume.v2.backup:ShowVolumeBackup')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: json, shell,
+            table, value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+runner_type: run-python

--- a/actions/volume.create.yaml
+++ b/actions/volume.create.yaml
@@ -1,57 +1,97 @@
 ---
-description: Create new volume
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: volume.create
 parameters:
     availability_zone:
-        description: Create new volume in <availability-zone>
+        description: Create volume in <availability-zone>
         type: string
     base:
         default: volume create
         immutable: true
         type: string
+    bootable:
+        default: false
+        description: Mark volume as bootable
+        type: boolean
+    cloud:
+        description: A specific cloud to query
+        type: string
+    consistency_group:
+        description: Consistency group where the new volume belongs to
+        type: string
     description:
-        description: New volume description
+        description: Volume description
         type: string
     ep:
-        default: EntryPoint.parse('volume_create = openstackclient.volume.v1.volume:CreateVolume')
+        default: EntryPoint.parse('volume_create = openstackclient.volume.v2.volume:CreateVolume')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
         type: string
+    hint:
+        description: Arbitrary scheduler hint key-value pairs to help boot an instance
+            (repeat option to set multiple hints)
+        type: array
     image:
-        description: Use <image> as source of new volume (name or ID)
+        description: Use <image> as source of volume (name or ID)
         type: string
+    multi_attach:
+        default: false
+        description: Allow volume to be attached more than once (default to False)
+        type: boolean
     name:
-        description: New volume name
+        description: Volume name
         required: true
         type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    non_bootable:
+        default: false
+        description: Mark volume as non-bootable (default)
+        type: boolean
     project:
         description: Specify an alternate project (name or ID)
         type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
     property:
-        description: Set a property on this volume (repeat option to set multiple
+        description: Set a property to this volume (repeat option to set multiple
             properties)
         type: array
+    read_only:
+        default: false
+        description: Set volume to read-only access mode
+        type: boolean
+    read_write:
+        default: false
+        description: Set volume to read-write access mode (default)
+        type: boolean
     size:
-        description: New volume size in GB
-        required: true
+        description: Volume size in GB (Required unless --snapshot or --source or
+            --source-replicated is specified)
         type: integer
     snapshot:
-        description: Use <snapshot> as source of new volume
-        type: string
-    snapshot_id:
-        description: ==SUPPRESS==
+        description: Use <snapshot> as source of volume (name or ID)
         type: string
     source:
         description: Volume to clone (name or ID)
         type: string
+    source_replicated:
+        description: Replicated volume to clone (name or ID)
+        type: string
     type:
-        description: Use <volume-type> as the new volume type
+        description: Set the type of volume
         type: string
     user:
         description: Specify an alternate user (name or ID)

--- a/actions/volume.delete.yaml
+++ b/actions/volume.delete.yaml
@@ -1,5 +1,5 @@
 ---
-description: Delete volume(s)
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: volume.delete
@@ -8,14 +8,27 @@ parameters:
         default: volume delete
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
-        default: EntryPoint.parse('volume_delete = openstackclient.volume.v1.volume:DeleteVolume')
+        default: EntryPoint.parse('volume_delete = openstackclient.volume.v2.volume:DeleteVolume')
         immutable: true
         type: string
     force:
         default: false
         description: Attempt forced removal of volume(s), regardless of state (defaults
             to False)
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    purge:
+        default: false
+        description: Remove any snapshots along with volume(s) (defaults to False)
         type: boolean
     volumes:
         description: Volume(s) to delete (name or ID)

--- a/actions/volume.host.set.yaml
+++ b/actions/volume.host.set.yaml
@@ -1,0 +1,36 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: volume.host.set
+parameters:
+    base:
+        default: volume host set
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    disable:
+        default: false
+        description: Freeze and disable the specified volume host.
+        type: boolean
+    enable:
+        default: false
+        description: Thaw and enable the specified volume host.
+        type: boolean
+    ep:
+        default: EntryPoint.parse('volume_host_set = openstackclient.volume.v2.volume_host:SetVolumeHost')
+        immutable: true
+        type: string
+    host:
+        description: Name of volume host
+        required: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+runner_type: run-python

--- a/actions/volume.list.yaml
+++ b/actions/volume.list.yaml
@@ -1,5 +1,5 @@
 ---
-description: List volumes
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: volume.list
@@ -12,23 +12,56 @@ parameters:
         default: volume list
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
-        default: EntryPoint.parse('volume_list = openstackclient.volume.v1.volume:ListVolume')
+        default: EntryPoint.parse('volume_list = openstackclient.volume.v2.volume:ListVolume')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: csv, html, json,
-            table, yaml)'
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
         type: string
+    limit:
+        description: Maximum number of volumes to display
+        type: integer
     long:
         default: false
         description: List additional fields in output
         type: boolean
+    marker:
+        description: The last volume ID of the previous page
+        type: string
     name:
-        description: Filter results by name
+        description: Filter results by volume name
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project:
+        description: Filter results by project (name or ID) (admin only)
+        type: string
+    project_domain:
+        description: Domain the project belongs to (name or ID). This can be used
+            in case collisions between project names exist.
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     status:
         description: Filter results by status
+        type: string
+    user:
+        description: Filter results by user (name or ID) (admin only)
+        type: string
+    user_domain:
+        description: Domain the user belongs to (name or ID). This can be used in
+            case collisions between user names exist.
         type: string
 runner_type: run-python

--- a/actions/volume.migrate.yaml
+++ b/actions/volume.migrate.yaml
@@ -1,0 +1,47 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: volume.migrate
+parameters:
+    base:
+        default: volume migrate
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('volume_migrate = openstackclient.volume.v2.volume:MigrateVolume')
+        immutable: true
+        type: string
+    force_host_copy:
+        default: false
+        description: Enable generic host-based force-migration, which bypasses driver
+            optimizations
+        type: boolean
+    host:
+        description: 'Destination host (takes the form: host@backend-name#pool)'
+        required: true
+        type: string
+    lock_volume:
+        default: false
+        description: If specified, the volume state will be locked and will not allow
+            a migration to be aborted (possibly by another operation)
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    unlock_volume:
+        default: false
+        description: If specified, the volume state will not be locked and the a migration
+            can be aborted (default) (possibly by another operation)
+        type: boolean
+    volume:
+        description: Volume to migrate (name or ID)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/volume.qos.associate.yaml
+++ b/actions/volume.qos.associate.yaml
@@ -1,0 +1,32 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: volume.qos.associate
+parameters:
+    base:
+        default: volume qos associate
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('volume_qos_associate = openstackclient.volume.v2.qos_specs:AssociateQos')
+        immutable: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    qos_spec:
+        description: QoS specification to modify (name or ID)
+        required: true
+        type: string
+    volume_type:
+        description: Volume type to associate the QoS (name or ID)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/volume.qos.create.yaml
+++ b/actions/volume.qos.create.yaml
@@ -1,0 +1,46 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: volume.qos.create
+parameters:
+    base:
+        default: volume qos create
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    consumer:
+        default: both
+        description: 'Consumer of the QoS. Valid consumers: back-end, both, front-end
+            (defaults to ''both'') (choices: front-end, back-end, both)'
+        type: string
+    ep:
+        default: EntryPoint.parse('volume_qos_create = openstackclient.volume.v2.qos_specs:CreateQos')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: json, shell,
+            table, value, yaml)'
+        type: string
+    name:
+        description: New QoS specification name
+        required: true
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    property:
+        description: Set a QoS specification property (repeat option to set multiple
+            properties)
+        type: array
+runner_type: run-python

--- a/actions/volume.qos.delete.yaml
+++ b/actions/volume.qos.delete.yaml
@@ -1,0 +1,32 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: volume.qos.delete
+parameters:
+    base:
+        default: volume qos delete
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('volume_qos_delete = openstackclient.volume.v2.qos_specs:DeleteQos')
+        immutable: true
+        type: string
+    force:
+        default: false
+        description: Allow to delete in-use QoS specification(s)
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    qos_specs:
+        description: QoS specification(s) to delete (name or ID)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/volume.qos.disassociate.yaml
+++ b/actions/volume.qos.disassociate.yaml
@@ -1,0 +1,35 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: volume.qos.disassociate
+parameters:
+    all:
+        default: false
+        description: Disassociate the QoS from every volume type
+        type: boolean
+    base:
+        default: volume qos disassociate
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('volume_qos_disassociate = openstackclient.volume.v2.qos_specs:DisassociateQos')
+        immutable: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    qos_spec:
+        description: QoS specification to modify (name or ID)
+        required: true
+        type: string
+    volume_type:
+        description: Volume type to disassociate the QoS from (name or ID)
+        type: string
+runner_type: run-python

--- a/actions/volume.qos.list.yaml
+++ b/actions/volume.qos.list.yaml
@@ -1,0 +1,33 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: volume.qos.list
+parameters:
+    base:
+        default: volume qos list
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('volume_qos_list = openstackclient.volume.v2.qos_specs:ListQos')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+runner_type: run-python

--- a/actions/volume.qos.set.yaml
+++ b/actions/volume.qos.set.yaml
@@ -1,0 +1,32 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: volume.qos.set
+parameters:
+    base:
+        default: volume qos set
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('volume_qos_set = openstackclient.volume.v2.qos_specs:SetQos')
+        immutable: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    property:
+        description: Property to add or modify for this QoS specification (repeat
+            option to set multiple properties)
+        type: array
+    qos_spec:
+        description: QoS specification to modify (name or ID)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/volume.qos.show.yaml
+++ b/actions/volume.qos.show.yaml
@@ -1,0 +1,37 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: volume.qos.show
+parameters:
+    base:
+        default: volume qos show
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('volume_qos_show = openstackclient.volume.v2.qos_specs:ShowQos')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: json, shell,
+            table, value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    qos_spec:
+        description: QoS specification to display (name or ID)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/volume.qos.unset.yaml
+++ b/actions/volume.qos.unset.yaml
@@ -1,0 +1,33 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: volume.qos.unset
+parameters:
+    base:
+        default: volume qos unset
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('volume_qos_unset = openstackclient.volume.v2.qos_specs:UnsetQos')
+        immutable: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    property:
+        default: []
+        description: Property to remove from the QoS specification. (repeat option
+            to unset multiple properties)
+        type: array
+    qos_spec:
+        description: QoS specification to modify (name or ID)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/volume.service.list.yaml
+++ b/actions/volume.service.list.yaml
@@ -1,0 +1,43 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: volume.service.list
+parameters:
+    base:
+        default: volume service list
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('volume_service_list = openstackclient.volume.v2.service:ListService')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
+        type: string
+    host:
+        description: List services on specified host (name only)
+        type: string
+    long:
+        default: false
+        description: List additional fields in output
+        type: boolean
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    service:
+        description: List only specified service (name only)
+        type: string
+runner_type: run-python

--- a/actions/volume.service.set.yaml
+++ b/actions/volume.service.set.yaml
@@ -1,0 +1,44 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: volume.service.set
+parameters:
+    base:
+        default: volume service set
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    disable:
+        default: false
+        description: Disable volume service
+        type: boolean
+    disable_reason:
+        description: Reason for disabling the service (should be used with --disable
+            option)
+        type: string
+    enable:
+        default: false
+        description: Enable volume service
+        type: boolean
+    ep:
+        default: EntryPoint.parse('volume_service_set = openstackclient.volume.v2.service:SetService')
+        immutable: true
+        type: string
+    host:
+        description: Name of host
+        required: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    service:
+        description: Name of service (Binary name)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/volume.set.yaml
+++ b/actions/volume.set.yaml
@@ -1,5 +1,5 @@
 ---
-description: Set volume properties
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: volume.set
@@ -8,25 +8,70 @@ parameters:
         default: volume set
         immutable: true
         type: string
+    bootable:
+        default: false
+        description: Mark volume as bootable
+        type: boolean
+    cloud:
+        description: A specific cloud to query
+        type: string
     description:
         description: New volume description
         type: string
     ep:
-        default: EntryPoint.parse('volume_set = openstackclient.volume.v1.volume:SetVolume')
+        default: EntryPoint.parse('volume_set = openstackclient.volume.v2.volume:SetVolume')
         immutable: true
         type: string
+    image_property:
+        description: Set an image property on this volume (repeat option to set multiple
+            image properties)
+        type: array
     name:
         description: New volume name
         type: string
+    non_bootable:
+        default: false
+        description: Mark volume as non-bootable
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
     property:
-        description: Property to add or modify for this volume (repeat option to set
-            multiple properties)
+        description: Set a property on this volume (repeat option to set multiple
+            properties)
         type: array
+    read_only:
+        default: false
+        description: Set volume to read-only access mode
+        type: boolean
+    read_write:
+        default: false
+        description: Set volume to read-write access mode
+        type: boolean
+    retype_policy:
+        description: 'Migration policy while re-typing volume ("never" or "on-demand",
+            default is "never" ) (available only when "--type" option is specified)
+            (choices: never, on-demand)'
+        type: string
     size:
         description: Extend volume size in GB
         type: integer
+    state:
+        description: 'New volume state ("available", "error", "creating", "deleting",
+            "in-use", "attaching", "detaching", "error_deleting" or "maintenance")
+            (admin only) (This option simply changes the state of the volume in the
+            database with no regard to actual status, exercise caution when using)
+            (choices: available, error, creating, deleting, in-use, attaching, detaching,
+            error_deleting, maintenance)'
+        type: string
+    type:
+        description: New volume type (name or ID)
+        type: string
     volume:
-        description: Volume to change (name or ID)
+        description: Volume to modify (name or ID)
         required: true
         type: string
 runner_type: run-python

--- a/actions/volume.show.yaml
+++ b/actions/volume.show.yaml
@@ -1,5 +1,5 @@
 ---
-description: Show volume details
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: volume.show
@@ -8,14 +8,27 @@ parameters:
         default: volume show
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
-        default: EntryPoint.parse('volume_show = openstackclient.volume.v1.volume:ShowVolume')
+        default: EntryPoint.parse('volume_show = openstackclient.volume.v2.volume:ShowVolume')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
         type: string
     volume:
         description: Volume to display (name or ID)

--- a/actions/volume.snapshot.create.yaml
+++ b/actions/volume.snapshot.create.yaml
@@ -1,0 +1,55 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: volume.snapshot.create
+parameters:
+    base:
+        default: volume snapshot create
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    description:
+        description: Description of the snapshot
+        type: string
+    ep:
+        default: EntryPoint.parse('volume_snapshot_create = openstackclient.volume.v2.volume_snapshot:CreateVolumeSnapshot')
+        immutable: true
+        type: string
+    force:
+        default: false
+        description: Create a snapshot attached to an instance. Default is False
+        type: boolean
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: json, shell,
+            table, value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    property:
+        description: Set a property to this snapshot (repeat option to set multiple
+            properties)
+        type: array
+    remote_source:
+        description: 'The attribute(s) of the exsiting remote volume snapshot (admin
+            required) (repeat option to specify multiple attributes) e.g.: ''--remote-source
+            source-name=test_name --remote-source source-id=test_id'''
+        type: array
+    snapshot_name:
+        description: Name of the new snapshot (default to None)
+        type: string
+    volume:
+        description: Volume to snapshot (name or ID) (default is <snapshot-name>)
+        type: string
+runner_type: run-python

--- a/actions/volume.snapshot.delete.yaml
+++ b/actions/volume.snapshot.delete.yaml
@@ -1,0 +1,33 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: volume.snapshot.delete
+parameters:
+    base:
+        default: volume snapshot delete
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('volume_snapshot_delete = openstackclient.volume.v2.volume_snapshot:DeleteVolumeSnapshot')
+        immutable: true
+        type: string
+    force:
+        default: false
+        description: Attempt forced removal of snapshot(s), regardless of state (defaults
+            to False)
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    snapshots:
+        description: Snapshot(s) to delete (name or ID)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/volume.snapshot.list.yaml
+++ b/actions/volume.snapshot.list.yaml
@@ -1,0 +1,58 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: volume.snapshot.list
+parameters:
+    all_projects:
+        default: false
+        description: Include all projects (admin only)
+        type: boolean
+    base:
+        default: volume snapshot list
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('volume_snapshot_list = openstackclient.volume.v2.volume_snapshot:ListVolumeSnapshot')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
+        type: string
+    limit:
+        description: Maximum number of snapshots to display
+        type: integer
+    long:
+        default: false
+        description: List additional fields in output
+        type: boolean
+    marker:
+        description: The last snapshot ID of the previous page
+        type: string
+    name:
+        description: Filters results by a name.
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    status:
+        description: 'Filters results by a status. (''available'', ''error'', ''creating'',
+            ''deleting'' or ''error-deleting'') (choices: available, error, creating,
+            deleting, error-deleting)'
+        type: string
+    volume:
+        description: Filters results by a volume (name or ID).
+        type: string
+runner_type: run-python

--- a/actions/volume.snapshot.set.yaml
+++ b/actions/volume.snapshot.set.yaml
@@ -1,0 +1,44 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: volume.snapshot.set
+parameters:
+    base:
+        default: volume snapshot set
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    description:
+        description: New snapshot description
+        type: string
+    ep:
+        default: EntryPoint.parse('volume_snapshot_set = openstackclient.volume.v2.volume_snapshot:SetVolumeSnapshot')
+        immutable: true
+        type: string
+    name:
+        description: New snapshot name
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    property:
+        description: Property to add/change for this snapshot (repeat option to set
+            multiple properties)
+        type: array
+    snapshot:
+        description: Snapshot to modify (name or ID)
+        required: true
+        type: string
+    state:
+        description: 'New snapshot state. ("available", "error", "creating", "deleting",
+            or "error_deleting") (admin only) (This option simply changes the state
+            of the snapshot in the database with no regard to actual status, exercise
+            caution when using) (choices: available, error, creating, deleting, error-deleting)'
+        type: string
+runner_type: run-python

--- a/actions/volume.snapshot.show.yaml
+++ b/actions/volume.snapshot.show.yaml
@@ -1,0 +1,37 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: volume.snapshot.show
+parameters:
+    base:
+        default: volume snapshot show
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('volume_snapshot_show = openstackclient.volume.v2.volume_snapshot:ShowVolumeSnapshot')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: json, shell,
+            table, value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    snapshot:
+        description: Snapshot to display (name or ID)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/volume.snapshot.unset.yaml
+++ b/actions/volume.snapshot.unset.yaml
@@ -1,0 +1,33 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: volume.snapshot.unset
+parameters:
+    base:
+        default: volume snapshot unset
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('volume_snapshot_unset = openstackclient.volume.v2.volume_snapshot:UnsetVolumeSnapshot')
+        immutable: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    property:
+        default: []
+        description: Property to remove from snapshot (repeat option to remove multiple
+            properties)
+        type: array
+    snapshot:
+        description: Snapshot to modify (name or ID)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/volume.transfer.request.accept.yaml
+++ b/actions/volume.transfer.request.accept.yaml
@@ -1,0 +1,41 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: volume.transfer.request.accept
+parameters:
+    auth_key:
+        description: Authentication key of transfer request
+        required: true
+        type: string
+    base:
+        default: volume transfer request accept
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('volume_transfer_request_accept = openstackclient.volume.v2.volume_transfer_request:AcceptTransferRequest')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: json, shell,
+            table, value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    transfer_request:
+        description: Volume transfer request to accept (name or ID)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/volume.transfer.request.create.yaml
+++ b/actions/volume.transfer.request.create.yaml
@@ -1,0 +1,40 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: volume.transfer.request.create
+parameters:
+    base:
+        default: volume transfer request create
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('volume_transfer_request_create = openstackclient.volume.v2.volume_transfer_request:CreateTransferRequest')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: json, shell,
+            table, value, yaml)'
+        type: string
+    name:
+        description: New transfer request name (default to None)
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    volume:
+        description: Volume to transfer (name or ID)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/volume.transfer.request.delete.yaml
+++ b/actions/volume.transfer.request.delete.yaml
@@ -1,0 +1,28 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: volume.transfer.request.delete
+parameters:
+    base:
+        default: volume transfer request delete
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('volume_transfer_request_delete = openstackclient.volume.v2.volume_transfer_request:DeleteTransferRequest')
+        immutable: true
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    transfer_request:
+        description: Volume transfer request(s) to delete (name or ID)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/volume.transfer.request.list.yaml
+++ b/actions/volume.transfer.request.list.yaml
@@ -1,0 +1,37 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: volume.transfer.request.list
+parameters:
+    all_projects:
+        default: false
+        description: Shows detail for all projects. Admin only. (defaults to False)
+        type: boolean
+    base:
+        default: volume transfer request list
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('volume_transfer_request_list = openstackclient.volume.v2.volume_transfer_request:ListTransferRequest')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+runner_type: run-python

--- a/actions/volume.transfer.request.show.yaml
+++ b/actions/volume.transfer.request.show.yaml
@@ -1,0 +1,37 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: volume.transfer.request.show
+parameters:
+    base:
+        default: volume transfer request show
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('volume_transfer_request_show = openstackclient.volume.v2.volume_transfer_request:ShowTransferRequest')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: json, shell,
+            table, value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    transfer_request:
+        description: Volume transfer request to display (name or ID)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/volume.type.create.yaml
+++ b/actions/volume.type.create.yaml
@@ -1,5 +1,5 @@
 ---
-description: Create new volume type
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: volume.type.create
@@ -8,21 +8,53 @@ parameters:
         default: volume type create
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    description:
+        description: Volume type description
+        type: string
     ep:
-        default: EntryPoint.parse('volume_type_create = openstackclient.volume.v1.type:CreateVolumeType')
+        default: EntryPoint.parse('volume_type_create = openstackclient.volume.v2.volume_type:CreateVolumeType')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
         type: string
     name:
-        description: New volume type name
+        description: Volume type name
         required: true
         type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    private:
+        default: false
+        description: Volume type is not accessible to the public
+        type: boolean
+    project:
+        description: Allow <project> to access private type (name or ID) (Must be
+            used with --private option)
+        type: string
+    project_domain:
+        description: Domain the project belongs to (name or ID). This can be used
+            in case collisions between project names exist.
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
     property:
-        description: Property to add for this volume type (repeat option to set multiple
+        description: Set a property on this volume type (repeat option to set multiple
             properties)
         type: array
+    public:
+        default: false
+        description: Volume type is accessible to the public
+        type: boolean
 runner_type: run-python

--- a/actions/volume.type.delete.yaml
+++ b/actions/volume.type.delete.yaml
@@ -1,5 +1,5 @@
 ---
-description: Delete volume type
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: volume.type.delete
@@ -8,12 +8,21 @@ parameters:
         default: volume type delete
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
-        default: EntryPoint.parse('volume_type_delete = openstackclient.volume.v1.type:DeleteVolumeType')
+        default: EntryPoint.parse('volume_type_delete = openstackclient.volume.v2.volume_type:DeleteVolumeType')
         immutable: true
         type: string
-    volume_type:
-        description: Volume type to delete (name or ID)
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    volume_types:
+        description: Volume type(s) to delete (name or ID)
         required: true
         type: string
 runner_type: run-python

--- a/actions/volume.type.list.yaml
+++ b/actions/volume.type.list.yaml
@@ -1,5 +1,5 @@
 ---
-description: List volume types
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: volume.type.list
@@ -8,17 +8,42 @@ parameters:
         default: volume type list
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    default:
+        default: false
+        description: List the default volume type
+        type: boolean
     ep:
-        default: EntryPoint.parse('volume_type_list = openstackclient.volume.v1.type:ListVolumeType')
+        default: EntryPoint.parse('volume_type_list = openstackclient.volume.v2.volume_type:ListVolumeType')
         immutable: true
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: csv, html, json,
-            table, yaml)'
+        description: 'the output format, defaults to table (choices: csv, json, table,
+            value, yaml)'
         type: string
     long:
         default: false
         description: List additional fields in output
+        type: boolean
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    private:
+        default: false
+        description: List only private types (admin only)
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    public:
+        default: false
+        description: List only public types
         type: boolean
 runner_type: run-python

--- a/actions/volume.type.set.yaml
+++ b/actions/volume.type.set.yaml
@@ -1,5 +1,5 @@
 ---
-description: Set volume type properties
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: volume.type.set
@@ -8,13 +8,35 @@ parameters:
         default: volume type set
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    description:
+        description: Set volume type description
+        type: string
     ep:
-        default: EntryPoint.parse('volume_type_set = openstackclient.volume.v1.type:SetVolumeType')
+        default: EntryPoint.parse('volume_type_set = openstackclient.volume.v2.volume_type:SetVolumeType')
         immutable: true
         type: string
+    name:
+        description: Set volume type name
+        type: string
+    project:
+        description: Set volume type access to project (name or ID) (admin only)
+        type: string
+    project_domain:
+        description: Domain the project belongs to (name or ID). This can be used
+            in case collisions between project names exist.
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
     property:
-        description: Property to add or modify for this volume type (repeat option
-            to set multiple properties)
+        description: Set a property on this volume type (repeat option to set multiple
+            properties)
         type: array
     volume_type:
         description: Volume type to modify (name or ID)

--- a/actions/volume.type.show.yaml
+++ b/actions/volume.type.show.yaml
@@ -1,0 +1,37 @@
+---
+description: null
+enabled: true
+entry_point: src/wrapper.py
+name: volume.type.show
+parameters:
+    base:
+        default: volume type show
+        immutable: true
+        type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
+    ep:
+        default: EntryPoint.parse('volume_type_show = openstackclient.volume.v2.volume_type:ShowVolumeType')
+        immutable: true
+        type: string
+    format:
+        default: json
+        description: 'the output format, defaults to table (choices: json, shell,
+            table, value, yaml)'
+        type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
+    volume_type:
+        description: Volume type to display (name or ID)
+        required: true
+        type: string
+runner_type: run-python

--- a/actions/volume.type.unset.yaml
+++ b/actions/volume.type.unset.yaml
@@ -1,5 +1,5 @@
 ---
-description: Unset volume type properties
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: volume.type.unset
@@ -8,13 +8,28 @@ parameters:
         default: volume type unset
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
-        default: EntryPoint.parse('volume_type_unset = openstackclient.volume.v1.type:UnsetVolumeType')
+        default: EntryPoint.parse('volume_type_unset = openstackclient.volume.v2.volume_type:UnsetVolumeType')
         immutable: true
         type: string
+    project:
+        description: Removes volume type access to project (name or ID)  (admin only)
+        type: string
+    project_domain:
+        description: Domain the project belongs to (name or ID). This can be used
+            in case collisions between project names exist.
+        type: string
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
     property:
-        default: []
-        description: Property to remove from volume type (repeat option to remove
+        description: Remove a property from this volume type (repeat option to remove
             multiple properties)
         type: array
     volume_type:

--- a/actions/volume.unset.yaml
+++ b/actions/volume.unset.yaml
@@ -1,5 +1,5 @@
 ---
-description: Unset volume properties
+description: null
 enabled: true
 entry_point: src/wrapper.py
 name: volume.unset
@@ -8,13 +8,25 @@ parameters:
         default: volume unset
         immutable: true
         type: string
+    cloud:
+        description: A specific cloud to query
+        type: string
     ep:
-        default: EntryPoint.parse('volume_unset = openstackclient.volume.v1.volume:UnsetVolume')
+        default: EntryPoint.parse('volume_unset = openstackclient.volume.v2.volume:UnsetVolume')
         immutable: true
         type: string
+    image_property:
+        description: Remove an image property from volume (repeat option to remove
+            multiple image properties)
+        type: array
+    project_id:
+        description: Run the action under a different project, identified by id
+        type: string
+    project_name:
+        description: Run the action under a different project, identified by name
+        type: string
     property:
-        default: []
-        description: Property to remove from volume (repeat option to remove multiple
+        description: Remove a property from volume (repeat option to remove multiple
             properties)
         type: array
     volume:

--- a/etc/autogen.py
+++ b/etc/autogen.py
@@ -156,6 +156,19 @@ class CommandProcessor(object):
         }
         parameters['cloud'] = cloud_param
 
+        # Add project parameters to the action
+        project_name_param = {
+            'type': 'string',
+            'description': 'Run the action under a different project, identified by name'
+        }
+        parameters['project_name'] = project_name_param
+
+        project_id_param = {
+            'type': 'string',
+            'description': 'Run the action under a different project, identified by id'
+        }
+        parameters['project_id'] = project_id_param
+
         return parameters
 
     def __call__(self):

--- a/pack.yaml
+++ b/pack.yaml
@@ -1,7 +1,7 @@
 ---
 name: openstack
 description: OpenStack integration pack
-version: 0.2.0
+version: 0.3.0
 author: StackStorm Engineering Team
 email: support@stackstorm.com
 contributors:


### PR DESCRIPTION
This commit enables a project name or id to be specified per action.
This allows a user to run different actions against all projects
they belong to ad-hoc.