### PR TITLE
Fix deprecation warning

### DIFF
--- a/actions/src/lib/utils.py
+++ b/actions/src/lib/utils.py
@@ -1,6 +1,6 @@
 import argparse
 
-from openstackclient.common import parseractions
+from osc_lib.cli import parseractions
 
 DASH_PARAMETERS = [
     "rxtx_factor",

--- a/pack.yaml
+++ b/pack.yaml
@@ -1,7 +1,7 @@
 ---
 name: openstack
 description: OpenStack integration pack
-version: 0.3.0
+version: 0.3.1
 author: StackStorm Engineering Team
 email: support@stackstorm.com
 contributors:


### PR DESCRIPTION
With the latest openstack client and without this patch, `stderr` always reports a deprecation warning.