### PR TITLE
Update OpenStack environment variables

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.7.2
+
+- Update OpenStack authenticate environment variables for Keystone v3
+  compatible.
+
 ## 0.7.1
 
 - Version bump to fix tagging issue. No code changes.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ acquired from the service catalog.
 To acquire a token:
 
 ```sh
-curl -s -X POST $OS_AUTH_URL/tokens -H "Content-Type: application/json" -d '{"auth": {"tenantName": "'"$OS_TENANT_NAME"'", "passwordCredentials": {"username": "'"$OS_USERNAME"'", "password": "'"$OS_PASSWORD"'"}}}' | python -m json.tool
+curl -s -X POST $OS_AUTH_URL/tokens -H "Content-Type: application/json" -d '{"auth": {"tenantName": "'"$OS_PROJECT_NAME"'", "passwordCredentials": {"username": "'"$OS_USERNAME"'", "password": "'"$OS_PASSWORD"'"}}}' | python -m json.tool
 ```
 See the [OpenStack manual](http://docs.openstack.org/api/quick-start/content/index.html#authenticate) for more information.
 
@@ -30,7 +30,7 @@ See the [OpenStack manual](http://docs.openstack.org/api/quick-start/content/ind
 ---
 token:
     OS_TOKEN: "xxxxxxxxxxxxxxxxxxxx"
-    OS_URL: "http://{API_IP}:{API_PORT}/v2/{TENANT_ID}"
+    OS_URL: "http://{API_IP}:{API_PORT}/v2/{PROJECT_ID}"
 ```
 
 ### Password based
@@ -40,11 +40,15 @@ Tokens are ephemeral and typical expiry is short; in those cases it might be pre
 ```yaml
 ---
 password:
-    OS_AUTH_URL: # authentication url
-    OS_TENANT_ID: # id of the tenant
-    OS_TENANT_NAME: # name of the tenant
-    OS_USERNAME: # username
-    OS_PASSWORD: # password
+  OS_AUTH_URL: # authentication url
+  OS_PROJECT_ID: # id of the tenant
+  OS_PROJECT_NAME: # name of the tenant
+  OS_USERNAME: # username
+  OS_PASSWORD: # password
+  OS_IDENTITY_API_VERSION: # keystone version - default 3
+  OS_PROJECT_DOMAIN_ID: # project domain id - default 3
+  OS_USER_DOMAIN_ID: # user domain id = defeault 3
+  OS_REGION_NAME: # region name
 ```
 
 ## Actions

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -22,17 +22,32 @@
     required: false
     additionalProperties: false
     properties:
+      OS_IDENTITY_API_VERSION:
+        description: "OpenStack identity service api version"
+        type: "string"
+        default: "3"
       OS_AUTH_URL:
         description: "OpenStack Authentication URL"
         type: "string"
-      OS_TENANT_ID:
-        description: "OpenStack Tenant ID"
+      OS_PROJECT_ID:
+        description: "OpenStack Project ID"
         type: "string"
-      OS_TENANT_NAME:
-        description: "OpenStack Tenant Name"
+      OS_PROJECT_NAME:
+        description: "OpenStack Project Name"
         type: "string"
       OS_USERNAME:
         description: "OpenStack Username"
+        type: "string"
+      OS_PROJECT_DOMAIN_ID:
+        description: "OpenStack Project Domain ID"
+        type: "string"
+        default: "default"
+      OS_USER_DOMAIN_ID:
+        description: "OpenStack User Domain ID"
+        type: "string"
+        default: "default"
+      OS_REGION_NAME:
+        description: "OpenStack Region Name"
         type: "string"
       OS_PASSWORD:
         description: "OpenStack Password"

--- a/openstack.yaml.example
+++ b/openstack.yaml.example
@@ -6,21 +6,25 @@
 openstackrc: ""
 
 token:
-    OS_TOKEN: ""
-    OS_URL: ""
+  OS_TOKEN: ""
+  OS_URL: ""
 
 password:
-    OS_AUTH_URL: ""
-    OS_TENANT_ID: ""
-    OS_TENANT_NAME: ""
-    OS_USERNAME: ""
-    OS_PASSWORD: ""
+  OS_AUTH_URL: ""
+  OS_PROJECT_ID: ""
+  OS_PROJECT_NAME: ""
+  OS_USERNAME: ""
+  OS_PASSWORD: ""
+  OS_IDENTITY_API_VERSION: ""
+  OS_PROJECT_DOMAIN_ID: ""
+  OS_USER_DOMAIN_ID: ""
+  OS_REGION_NAME: ""
 
 messaging:
-    # The value for service type depends on how the zaqar service is
-    # registered under Keystone. Please refer to Keystone for the
-    # actual value for the service type.
-    service_type: 'messaging'
-    claim_ttl: 60
-    claim_grace: 60
-    queues: []
+  # The value for service type depends on how the zaqar service is
+  # registered under Keystone. Please refer to Keystone for the
+  # actual value for the service type.
+  service_type: 'messaging'
+  claim_ttl: 60
+  claim_grace: 60
+  queues: []

--- a/pack.yaml
+++ b/pack.yaml
@@ -4,7 +4,7 @@ description: OpenStack integration pack
 keywords:
   - openstack
   - private cloud
-version: 0.7.1
+version: 0.7.2
 author: StackStorm Engineering Team
 email: support@stackstorm.com
 contributors:


### PR DESCRIPTION
The origin environment variables are quite outdated now.
Let's update these to Keystone version 3 compatible.