### PR TITLE
Python 3 errors if get error on command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.8.1
+
+- Correct problem with error reporting on Python 3
+
 ## 0.8.0
 
 - Add group actions

--- a/actions/src/lib/base.py
+++ b/actions/src/lib/base.py
@@ -93,6 +93,6 @@ class OpenStackBaseAction(Action):
                 return out
         else:
             # put out and err to output streams
-            sys.stdout.write(out)
-            sys.stderr.write(err)
+            sys.stdout.write(six.ensure_str(out))
+            sys.stderr.write(six.ensure_str(err))
             sys.exit(exit)

--- a/pack.yaml
+++ b/pack.yaml
@@ -4,7 +4,7 @@ description: OpenStack integration pack
 keywords:
   - openstack
   - private cloud
-version: 0.8.0
+version: 0.8.1
 author: StackStorm Engineering Team
 email: support@stackstorm.com
 contributors:


### PR DESCRIPTION
When trying to run server.list and had problems with certificates then got the following error when running on CentOS8:

```
st2.actions.python.WrapperAction: DEBUG    Generated command "openstack server list -f json"
Traceback (most recent call last):
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/python_runner/python_action_wrapper.py", line 333, in <module>
    obj.run()
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/python_runner/python_action_wrapper.py", line 192, in run
    output = action.run(**self._parameters)
  File "/opt/stackstorm/packs/openstack/actions/src/lib/base.py", line 67, in run
    return self._format_output(out=out, err=err, exit=p.returncode)
  File "/opt/stackstorm/packs/openstack/actions/src/lib/base.py", line 96, in _format_output
    sys.stdout.write(out)
TypeError: write() argument must be str, not bytes
"
  stdout: ''

``

