### PR TITLE
Make python3 only, as latest pyrsistent only supports python2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.0.0
+
+- As latest pyrsistent only supports python3, update pack to be python3 only
+
 ## 0.8.1
 
 - Correct problem with error reporting on Python 3

--- a/pack.yaml
+++ b/pack.yaml
@@ -4,11 +4,10 @@ description: OpenStack integration pack
 keywords:
   - openstack
   - private cloud
-version: 0.8.1
+version: 1.0.0
 author: StackStorm Engineering Team
 email: support@stackstorm.com
 contributors:
   - Joe Topjian <joe@topjian.net>
 python_versions:
-  - "2"
   - "3"


### PR DESCRIPTION
Latest pysristent is python3 only.
Therefore 2 choices:

- Keep to latest pyrsistent and therefore make pack python3 only OR
- Amend to specify max version to use for pyrsistent.

Have updated to make python3 only, as python2 support is to be deprecated in future ST2 releases.

In addition due to the import of queue in utils.py which is not available on python2, even though the pack installed on py2 systems, it would not have worked correctly.