### PR TITLE
Fix broken pack so can install on python2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## 0.8.1
 
 - Correct problem with error reporting on Python 3
+- Updated dependencies so will install on Python 2 after pyrsistent updates
 
 ## 0.8.0
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 StackStorm pack for OpenStack integration.
 
+## Pre-Requisites
+
+Versions of this pack earlier than 1.0.0 install specific versions of Python dependencies.
+Your system must have a compiler installed first: - e.g. `apt install gcc` or `yum install gcc`.
+
+
 ## Configuration
 
 Copy the example configuration in [openstack.yaml.example](./openstack.yaml.example)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ python-cinderclient
 python-heatclient
 python-ceilometerclient
 python-zaqarclient
+pyrsistent<0.17


### PR DESCRIPTION
So that there is not a broken pack version for python2, updated current version so it can still install given that pysistent latest version is only python3

However to be able to specify a version in pack.yaml requirements the ST2 system needs to have gcc installed, so have also specified a warning to the README for this.